### PR TITLE
Update version switcher to v0.25.0

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,7 +1,7 @@
 [
   {
-    "name": "v0.17 (stable)",
-    "version": "0.17.0",
+    "name": "v0.25 (stable)",
+    "version": "0.25.0",
     "url": "https://causal-ts.readthedocs.io/en/stable/",
     "preferred": true
   }


### PR DESCRIPTION
## Summary
- `docs/_static/switcher.json` still advertised "v0.17 (stable)" pointing at `/en/stable/`. That URL 404s because the project has never had a Git tag/GitHub Release, so Read the Docs never built a `stable` version — every link on that (nonexistent) page 404s, including "Get Started".
- Now that `v0.25.0` has been tagged/released (bloomberg/causal-ts/releases/tag/v0.25.0), this updates the switcher name/version to match.

## Follow-up needed on readthedocs.org (not part of this PR)
- [ ] Sync versions so `v0.25.0` appears under the Versions tab
- [ ] Activate it and confirm it's aliased to `stable` (Automation Rules)