### PR TITLE
Add PyPI Trusted Publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,190 @@
+---
+name: release
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions: read-all
+
+concurrency:
+  group: release-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: test Python ${{ matrix.python-version }} (${{ matrix.profile }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.10"
+            install-target: ".[dev,dowhy,tigramite]"
+            profile: all-extras
+          - python-version: "3.11"
+            install-target: ".[dev,dowhy,tigramite]"
+            profile: all-extras
+          - python-version: "3.12"
+            install-target: ".[dev,dowhy,tigramite]"
+            profile: all-extras
+          - python-version: "3.13"
+            install-target: ".[dev,dowhy,tigramite]"
+            profile: all-extras
+          - python-version: "3.14"
+            install-target: ".[dev]"
+            profile: core
+    steps:
+      - name: harden runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0
+        with:
+          egress-policy: audit
+
+      - name: check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e "${{ matrix.install-target }}"
+
+      - name: run tests
+        run: python -m pytest tests/ -v --tb=short
+
+  build:
+    name: build distributions
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: harden runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0
+        with:
+          egress-policy: audit
+
+      - name: check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+
+      - name: set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: verify release tag matches package version
+        if: github.event_name == 'release'
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          python - <<'PY'
+          import os
+          import tomllib
+
+          with open("pyproject.toml", "rb") as file:
+              package_version = tomllib.load(file)["project"]["version"]
+
+          release_tag = os.environ["RELEASE_TAG"]
+          tag_version = release_tag.removeprefix("v")
+          if tag_version != package_version:
+              raise SystemExit(
+                  f"Release tag {release_tag!r} does not match "
+                  f"pyproject.toml version {package_version!r}."
+              )
+          print(f"Building causalts {package_version}")
+          PY
+
+      - name: build sdist and wheel
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+          python -m twine check dist/*
+
+      - name: upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  smoke-test-wheel:
+    name: smoke test wheel on Python ${{ matrix.python-version }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - name: harden runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0
+        with:
+          egress-policy: audit
+
+      - name: set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: install and import wheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python - <<'PY'
+          from importlib.metadata import version
+
+          import causalts
+
+          print(f"causalts {version('causalts')} imported from {causalts.__file__}")
+          PY
+          causal-ts --help
+
+  publish:
+    name: publish to PyPI
+    if: github.event_name == 'release'
+    needs: smoke-test-wheel
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/causalts
+    permissions:
+      id-token: write
+    steps:
+      - name: harden runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0
+        with:
+          egress-policy: audit
+
+      - name: download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,24 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        include:
+          - python-version: "3.10"
+            install-target: ".[dev,dowhy,tigramite]"
+            profile: all-extras
+          - python-version: "3.11"
+            install-target: ".[dev,dowhy,tigramite]"
+            profile: all-extras
+          - python-version: "3.12"
+            install-target: ".[dev,dowhy,tigramite]"
+            profile: all-extras
+          - python-version: "3.13"
+            install-target: ".[dev,dowhy,tigramite]"
+            profile: all-extras
+          - python-version: "3.14"
+            install-target: ".[dev]"
+            profile: core
     permissions:
       contents: read
     steps:
@@ -22,14 +38,23 @@ jobs:
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0
         with:
           egress-policy: audit
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+
       - name: set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
       - name: install dependencies
-        run: pip install -e ".[dev,dowhy,tigramite]"
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e "${{ matrix.install-target }}"
+
       - name: run tests
-        run: pytest tests/ -v --tb=short
+        run: python -m pytest tests/ -v --tb=short

--- a/README.md
+++ b/README.md
@@ -38,20 +38,22 @@ Causal-TS is a Python framework for causal discovery in time series data. It imp
 
 ### Installation
 
-1. Clone the repository:
+Install the latest release from PyPI:
 
-   ```bash
-   git clone https://github.com/bloomberg/causal-ts.git
-   cd causal-ts
-   ```
+```bash
+pip install causalts
+```
 
-2. Install dependencies:
+For development, install from a clone:
 
-   ```bash
-   pip install -e .
-   ```
+```bash
+git clone https://github.com/bloomberg/causal-ts.git
+cd causal-ts
+pip install -e ".[dev,dowhy,tigramite]"
+```
 
-   PyTorch is installed automatically. CUDA and Apple MPS are auto-detected at runtime; CPU is the fallback.
+PyTorch is installed automatically. CUDA and Apple MPS are auto-detected at
+runtime; CPU is the fallback.
 
 ## Quick Start
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,7 +19,8 @@ On <https://pypi.org>, sign in and add a **pending** publisher
 | Workflow filename | `release.yml` |
 | Environment name  | `pypi`        |
 
-`Owner` is the **GitHub org that owns the repo** (`github.com/bloomberg/...`),
+`Owner` is the **GitHub org that owns the repository**
+(`github.com/bloomberg/...`),
 not your PyPI username. The GitHub OIDC token asserts
 `repository_owner = bloomberg`, and PyPI matches it against this value.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,58 @@
+# Releasing `causalts` to PyPI
+
+Publishing is automated by `.github/workflows/release.yml` using PyPI
+[Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC). No API
+token or secret is stored in the repository.
+
+## One-time setup
+
+### 1. PyPI Trusted Publisher
+
+On <https://pypi.org>, sign in and add a **pending** publisher
+(Account settings → Publishing → Add a pending publisher) with:
+
+| Field             | Value         |
+| ----------------- | ------------- |
+| PyPI project name | `causalts`    |
+| Owner             | `bloomberg`   |
+| Repository name   | `causal-ts`   |
+| Workflow filename | `release.yml` |
+| Environment name  | `pypi`        |
+
+`Owner` is the **GitHub org that owns the repo** (`github.com/bloomberg/...`),
+not your PyPI username. The GitHub OIDC token asserts
+`repository_owner = bloomberg`, and PyPI matches it against this value.
+
+### 2. GitHub `pypi` environment
+
+In the repository, go to **Settings → Environments → New environment**, name it
+`pypi`, and add protections:
+
+- **Required reviewers** — a maintainer must approve before the `publish` job
+  runs (a human gate on every PyPI push).
+- **Deployment branches and tags** — restrict to protected tags matching `v*`.
+
+## Cutting a release
+
+1. Bump `project.version` in `pyproject.toml` (e.g. `0.25.1` → `0.25.2`) and
+   merge it to `main`. Confirm the `test` matrix is green.
+2. Create and publish a **GitHub Release** whose tag is the version prefixed
+   with `v` (e.g. `v0.25.2`). The tag must exactly match `pyproject.toml`;
+   `release.yml` fails the build otherwise.
+3. The workflow runs tests → builds sdist/wheel → smoke-tests the wheel on
+   Python 3.10–3.14 → waits for `pypi` environment approval → publishes.
+
+## Dry run (no publish)
+
+Trigger the `release` workflow manually from the **Actions** tab
+(`workflow_dispatch`). It runs tests, builds, and smoke-tests the wheel but
+**skips publishing** (the `publish` job only runs on a `release` event).
+
+## Notes
+
+- Python 3.10–3.13 run the full optional-extra profile
+  (`.[dev,dowhy,tigramite]`); Python 3.14 runs the core profile (`.[dev]`)
+  because DoWhy does not yet advertise 3.14 support. The wheel is still
+  smoke-tested on 3.14.
+- The existing `v0.25.0` GitHub Release predates this workflow and will not
+  trigger it retroactively; the first automated publish is `v0.25.1`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "causalts"
-version = "0.25.0"
+version = "0.25.1"
 description = "Causal Discovery for Time Series"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -29,6 +29,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [


### PR DESCRIPTION
Sets up automated PyPI publishing for `causalts` so users can `pip install causalts`.

## What's here
- **`.github/workflows/release.yml`** (new): `test` → `build` (sdist+wheel) → `smoke-test-wheel` → `publish`. Publishing uses PyPI **Trusted Publishing (OIDC)** — no stored API token. The `publish` job runs only on a `release: published` event and is gated on the `pypi` GitHub environment. Includes a tag/version equality check and pinned action SHAs.
- **`.github/workflows/test.yml`**: matrix expanded to Python **3.10–3.14** (`fail-fast: false`, pip caching). 3.10–3.13 run the full extra profile `.[dev,dowhy,tigramite]`; **3.14 runs the core profile `.[dev]`** since DoWhy doesn't yet advertise 3.14 support (wheel is still smoke-tested on 3.14).
- **`pyproject.toml`**: add `3.13`/`3.14` classifiers; bump `version` `0.25.0` → **`0.25.1`** (first automated PyPI release).
- **`README.md`**: `pip install causalts` + dev-install from clone.
- **`RELEASING.md`**: Trusted Publisher + `pypi` environment setup and the release procedure.

## Verified locally
- `python -m build` ✅ and `twine check` ✅ (both sdist + wheel, `0.25.1`)
- `causal-ts` console entry point present in wheel metadata
- Core deps install on Python 3.14 in an isolated venv
- Both workflow YAML files parse

## Follow-up (out of band, before tagging a release)
1. Create the PyPI account + **pending Trusted Publisher**: project `causalts`, owner `bloomberg`, repo `causal-ts`, workflow `release.yml`, environment `pypi`.
2. Create the GitHub **`pypi` environment** (required reviewer + `v*` tag restriction).
3. Optionally dry-run via *Run workflow* (builds/smoke-tests, skips publish).
4. Tag & publish a GitHub Release `v0.25.1` to trigger the first publish.

See `RELEASING.md` for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)