### PR TITLE
Fix smoke-test-wheel: remove pip cache (no checkout in that job)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,6 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
 
       - name: download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
The `release` dry run (workflow_dispatch) failed on **all** smoke-test-wheel legs (3.10–3.14) with:

```
##[error]No file matched to [**/requirements.txt or **/pyproject.toml],
make sure you have checked out the target repository
```

## Cause
The `smoke-test-wheel` job installs a **prebuilt wheel** and intentionally does *not* check out the repository (the point is to test the wheel in isolation). But its `actions/setup-python` step set `cache: pip`, which needs a `requirements.txt`/`pyproject.toml` in the workspace to hash — none exists there, so the job errored at **setup**, before installing the wheel. So this is a CI-config bug, not a packaging problem; `test`/`build` (which check out the source) passed.

## Fix
Remove `cache: pip` from the `smoke-test-wheel` job only. The `test` and `build` jobs keep their cache (they check out the source and set `cache-dependency-path: pyproject.toml`).

After this merges, re-run the `release` dry run to confirm the smoke test goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)