### PR TITLE
Fix and streamline linting (python-lint + super-linter)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,19 @@ jobs:
           YAML_CONFIG_FILE: ".yamllint.yml"
           VALIDATE_ALL_CODEBASE: false
           MULTI_STATUS: false
+          # Python is linted by the dedicated python-lint job below.
+          VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_FLAKE8: false
+          VALIDATE_PYTHON_ISORT: false
+          VALIDATE_PYTHON_PYLINT: false
+          VALIDATE_PYTHON_MYPY: false
+          VALIDATE_PYTHON_RUFF: false
+          VALIDATE_PYTHON_PYINK: false
+          # Low-signal validators for a research codebase (copy-paste
+          # detector, prose style, competing markdown formatter).
+          VALIDATE_JSCPD: false
+          VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_MARKDOWN_PRETTIER: false
 
   python-lint:
     runs-on: ubuntu-latest
@@ -50,10 +63,10 @@ jobs:
           python-version: "3.12"
           cache: pip
       - name: Install linting tools
-        run: pip install black==24.* isort flake8
+        run: pip install black==24.* isort flake8 Flake8-pyproject
       - name: black
-        run: black --check --line-length 88 --target-version py312 .
+        run: black --check .
       - name: isort
-        run: isort --check --profile black --line-length 88 .
+        run: isort --check .
       - name: flake8
-        run: flake8 --max-line-length 88 --ignore E203,E501,W503 .
+        run: flake8 .

--- a/causalts/algorithms/__init__.py
+++ b/causalts/algorithms/__init__.py
@@ -69,7 +69,5 @@ def run_algorithm(name: str, df, ci_test, max_lag, **kwargs):
     CausalResult
     """
     if name not in _ALGO_REGISTRY:
-        raise ValueError(
-            f"Unknown algorithm {name!r}. Available: {list_algorithms()}"
-        )
+        raise ValueError(f"Unknown algorithm {name!r}. Available: {list_algorithms()}")
     return _ALGO_REGISTRY[name](df=df, ci_test=ci_test, max_lag=max_lag, **kwargs)

--- a/causalts/cdnots/uc_sepset.py
+++ b/causalts/cdnots/uc_sepset.py
@@ -141,21 +141,21 @@ def uc_sepset(
         # j is always the lag-0 endpoint (y is at lag 0 by _is_contemp_triple)
         # x and z may be lagged. Identify the lag-0 side (j) and the other (i).
         # PCMCI+ builds subsets from neighbors of j and (if i is also lag-0) of i.
-        j = z if z < no_of_inst_var else x   # the contemporaneous endpoint
-        i = x if z < no_of_inst_var else z   # could be lagged
+        j = z if z < no_of_inst_var else x  # the contemporaneous endpoint
+        i = x if z < no_of_inst_var else z  # could be lagged
 
         # Contemporaneous neighbors of j, excluding only the direct test partner i.
         # y is NOT excluded — PCMCI+ includes y in conditioning subsets.
         contemp_neighbors_j = [
-            p for p in cg_new.neighbors(j)
+            p
+            for p in cg_new.neighbors(j)
             if p < no_of_inst_var and p != (i if i < no_of_inst_var else -1)
         ]
         # If i is also lag-0, include its contemp neighbors too (excluding j)
         contemp_neighbors_i = []
         if i < no_of_inst_var:
             contemp_neighbors_i = [
-                p for p in cg_new.neighbors(i)
-                if p < no_of_inst_var and p != j
+                p for p in cg_new.neighbors(i) if p < no_of_inst_var and p != j
             ]
 
         # Build all unique subsets (union of both sides)

--- a/causalts/cedar/__init__.py
+++ b/causalts/cedar/__init__.py
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .discovery import Cedar, run_cedar  # noqa: F401
-from .result import CedarResult  # noqa: F401
 from .legacy import SYPI  # noqa: F401  # deprecated — use run_cedar / Cedar
+from .result import CedarResult  # noqa: F401

--- a/causalts/grace/__init__.py
+++ b/causalts/grace/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2025 Bloomberg Finance L.P.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from ..algorithms import register_algorithm
 from .gated_discovery import (
     GatedCausalDiscovery,
     StabilitySelector,
@@ -12,8 +13,6 @@ from .gated_discovery import (
     run_stability_selection,
 )
 from .result import GraceResult  # noqa: F401
-
-from ..algorithms import register_algorithm
 
 register_algorithm("grace")(run_cdnots_gated)
 register_algorithm("grace-ss")(run_stability_selection)

--- a/causalts/grace/gated_discovery.py
+++ b/causalts/grace/gated_discovery.py
@@ -13,7 +13,7 @@ import logging
 import math
 import os
 import warnings
-from typing import Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -23,6 +23,9 @@ import torch.nn.functional as F
 from pytorch_lightning import LightningModule, Trainer  # noqa: E402
 from pytorch_lightning.callbacks import EarlyStopping  # noqa: E402
 from torch.utils.data import DataLoader, TensorDataset
+
+if TYPE_CHECKING:
+    from .result import GraceResult
 
 EPS = 1e-6
 
@@ -330,7 +333,7 @@ def prepare_data(
     return TensorDataset(windows)
 
 
-from ..utils.helpers import evaluate_graph  # noqa: F401
+from ..utils.helpers import evaluate_graph  # noqa: E402,F401
 
 # ---------------------------------------------------------------------------
 # Self-contained MLP decoder
@@ -896,8 +899,8 @@ class StabilitySelector:
                     # Keep top-K by value, zero rest
                     ranked = sorted(
                         lags_on,
-                        key=lambda l: values[i, l, j],
-                        reverse=True,  # noqa: E741
+                        key=lambda lag: values[i, lag, j],
+                        reverse=True,
                     )
                     for lag_idx in ranked[k:]:
                         active[i, lag_idx, j] = 0
@@ -1292,12 +1295,10 @@ def run_ci_skeleton(
     """
     try:
         from ..cdnots.skeleton_discovery import (
-            c_lag_cnst,
             initialize_graph,
             skeleton_cnst,
             skeleton_discovery,
         )
-        from ..ci_tests.parcorr import PartialCorr
     except ImportError as e:
         raise ImportError(
             "causalts package required for CI skeleton. "
@@ -1679,8 +1680,6 @@ def _cdnots_graph_to_binary(cg_tig, n_vars: int, max_lag: int) -> np.ndarray:
         elif L > target_L:
             G = G[:, :, :target_L]
         return G
-
-
 
 
 def run_cdnots_gated(

--- a/causalts/plotting/_core.py
+++ b/causalts/plotting/_core.py
@@ -35,7 +35,6 @@ import matplotlib.transforms as transforms
 import networkx as nx
 import numpy as np
 from matplotlib import pyplot, ticker
-from mpl_toolkits.axisartist.axislines import Axes
 
 
 def _myround(x, base=5, round_mode="updown"):

--- a/causalts/plotting/compare.py
+++ b/causalts/plotting/compare.py
@@ -403,9 +403,7 @@ def compare_graphs(
                     else:
                         parts.append(f"{l}\u2717")
                 label = ",".join(parts)
-                _draw_arrow(
-                    ax, i, j, edge_color, edge_style, edge_lw, label, zorder=0
-                )
+                _draw_arrow(ax, i, j, edge_color, edge_style, edge_lw, label, zorder=0)
 
             # Draw FN part as separate dashed arrow
             if lags_fn:
@@ -457,7 +455,7 @@ def compare_graphs(
 
 
 # Re-export from canonical location (causalts.cdnots) for backwards compatibility
-from ..cdnots.phase3_utils import build_pvalue_matrix  # noqa: F401
+from ..cdnots.phase3_utils import build_pvalue_matrix  # noqa: E402,F401
 
 # ======================================================================
 # Metrics summary bar chart

--- a/causalts/regime/__init__.py
+++ b/causalts/regime/__init__.py
@@ -3,6 +3,13 @@
 
 """Regime-conditional causal discovery framework."""
 
+from .changepoint import (  # noqa: F401
+    CusumRegimeDetector,
+    EnsembleRegimeDetector,
+    HMMRegimeDetector,
+    KSRegimeDetector,
+    LeveneRegimeDetector,
+)
 from .config import RegimeConfig, RegimeParams  # noqa: F401
 from .detection import (  # noqa: F401
     ChangePointRegimeDetector,
@@ -12,12 +19,5 @@ from .detection import (  # noqa: F401
     SeasonalRegimeDetector,
 )
 from .discovery import run_regime_discovery  # noqa: F401
-from .changepoint import (  # noqa: F401
-    CusumRegimeDetector,
-    EnsembleRegimeDetector,
-    HMMRegimeDetector,
-    KSRegimeDetector,
-    LeveneRegimeDetector,
-)
 from .pelt import PeltRegimeDetector  # noqa: F401
 from .result import RegimeResult  # noqa: F401

--- a/causalts/synthetic_data/synthetic_datasets.py
+++ b/causalts/synthetic_data/synthetic_datasets.py
@@ -9,7 +9,6 @@ import numpy as np
 import pandas as pd
 
 from .structural_causal_processes import (
-    check_stationarity,
     generate_structural_causal_process,
     structural_causal_process,
 )

--- a/causalts/tigramite_discovery.py
+++ b/causalts/tigramite_discovery.py
@@ -55,8 +55,6 @@ class CITestAdapter:
     """
 
     def __init__(self, gpu_test, significance="analytic", verbosity=0):
-        from .ci_tests.independence_tests_base import CondIndTest
-
         self._gpu_test = gpu_test
         self._cached_pval = None
         self.significance = significance
@@ -796,9 +794,7 @@ def run_rpcmci(
     regime_graphs = {}
     for r in range(num_regimes):
         if r in causal_results and "graph" in causal_results[r]:
-            regime_graphs[r] = _tigramite_graph_to_binary(
-                causal_results[r]["graph"]
-            )
+            regime_graphs[r] = _tigramite_graph_to_binary(causal_results[r]["graph"])
         else:
             regime_graphs[r] = np.zeros((d, d, tau_max + 1), dtype=np.int8)
 

--- a/causalts/utils/linearity.py
+++ b/causalts/utils/linearity.py
@@ -55,8 +55,8 @@ def check_linearity(data, alpha=0.05, max_lag=1, pairs=None):
             # Align X_i(t-lag) with Y_j(t), always keeping Y_j(t-1) as a control.
             # Using t=1..T-lag so that Y_j(t-1) is always available.
             start = max(lag, 1)
-            x = data[start - lag : T - lag, i]   # X_i(t-lag), t = start..T-1
-            y = data[start:, j]                    # Y_j(t),     t = start..T-1
+            x = data[start - lag : T - lag, i]  # X_i(t-lag), t = start..T-1
+            y = data[start:, j]  # Y_j(t),     t = start..T-1
             y_lag1 = data[start - 1 : T - 1, j]  # Y_j(t-1),   t = start..T-1
 
             if len(x) < 10:

--- a/docs/scripts/generate_thumbnails.py
+++ b/docs/scripts/generate_thumbnails.py
@@ -40,7 +40,7 @@ THUMBNAIL_INDEX: dict[str, int] = {
     # "tutorial": 2,           # use the 3rd image in tutorial.ipynb
     # "grace_high_dim": 1,     # use the 2nd image
     "multi_c_nonstationarity": 4,
-    "cedar_benchmark": 1,       # use the scaling line-plot (2nd image) instead of the compare_graphs
+    "cedar_benchmark": 1,  # use the scaling line-plot (2nd image) instead of the compare_graphs
 }
 
 BG_LIGHT = (248, 248, 253)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,20 @@ line_length = 88
 
 [tool.flake8]
 max-line-length = 88
-extend-ignore = ["E203", "W503", "E501"]
+# E203, E226, W503 conflict with black's formatting; E501 is enforced by black.
+extend-ignore = ["E203", "E226", "E501", "W503"]
+exclude = [
+  ".git",
+  "__pycache__",
+  "build",
+  "dist",
+  "docs",
+  "experiments",
+  ".venv",
+  "venv",
+]
+# __init__.py modules re-export names to form the public API.
+per-file-ignores = ["__init__.py:F401"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def dependent_data():
 def small_df():
     """Small 3-variable DataFrame for algorithm smoke tests."""
     rng = np.random.default_rng(42)
-    T, K = 80, 3
+    T = 80
     x0 = rng.standard_normal(T)
     x1 = np.zeros(T)
     x2 = np.zeros(T)

--- a/tests/test_cedar.py
+++ b/tests/test_cedar.py
@@ -7,14 +7,14 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from causalts.ci_tests import ParCorrGPU
-from causalts.result import CausalResult
 from causalts.cedar import Cedar, CedarResult, run_cedar
 from causalts.cedar.lag_selection import (
     compute_lag_importance,
     compute_lag_pvalues,
     select_lags,
 )
+from causalts.ci_tests import ParCorrGPU
+from causalts.result import CausalResult
 
 DEVICE = "cpu"
 
@@ -194,8 +194,7 @@ def test_partial_dcor_scores_differ_from_dcor(ar_df):
     imp_pdcor = compute_lag_importance(data, max_lag=2, method="partial_dcor")
     # Scores should differ because partial_dcor residualises the target first
     assert not np.allclose(imp_dcor, imp_pdcor, atol=1e-6), (
-        "partial_dcor scores are identical to dcor — "
-        "residualization is not running"
+        "partial_dcor scores are identical to dcor — " "residualization is not running"
     )
 
 
@@ -223,12 +222,15 @@ def test_partial_dcor_regression_f1(ci_test):
     f1_values = []
     for seed in [42, 56, 45, 123]:
         gen = SCPGraphGenerator(
-            n_vars=10, max_lag=2, density="sparse",
+            n_vars=10,
+            max_lag=2,
+            density="sparse",
             dependency_funcs=("lin", "lin", "nl1", "nl2"),
         )
         res = gen.sample(seed=seed, T=300, max_tries=10000)
         df, gt = res["df"], res["ground_truth"]
         from causalts.ci_tests import PartialCorr
+
         ci = PartialCorr(df.values)
         r = run_cedar(df, ci, alpha_cond1=0.01, alpha_cond2=0.01, max_lag=2)
         f1_values.append(_eval(r.cg_tig, gt))

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -9,7 +9,10 @@ import pytest
 
 dowhy = pytest.importorskip("dowhy")
 
-from causalts.effects.graph_bridge import graph_to_networkx, make_lagged_df
+from causalts.effects.graph_bridge import (  # noqa: E402
+    graph_to_networkx,
+    make_lagged_df,
+)
 
 
 def _simple_graph_and_data():

--- a/tests/test_grace.py
+++ b/tests/test_grace.py
@@ -4,7 +4,6 @@
 """Tests for GRACE (gated causal discovery) algorithm."""
 
 import numpy as np
-import pandas as pd
 import torch
 
 from causalts.grace.gated_discovery import (

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -7,9 +7,7 @@ import matplotlib
 
 matplotlib.use("Agg")
 
-import numpy as np
-
-from causalts.utils.helpers import evaluate_graph
+import numpy as np  # noqa: E402
 
 
 def _make_graph():

--- a/tests/test_synthetic_data.py
+++ b/tests/test_synthetic_data.py
@@ -10,7 +10,6 @@ from causalts.synthetic_data.synthetic_datasets import (
     SCPGraphGenerator,
     ex1_nl,
     ex2,
-    ex3,
     henon_chain,
     load_dataset,
 )

--- a/tests/test_tigramite_effects.py
+++ b/tests/test_tigramite_effects.py
@@ -9,7 +9,7 @@ import pytest
 
 tigramite = pytest.importorskip("tigramite")
 
-from causalts.effects.tigramite_effects import (
+from causalts.effects.tigramite_effects import (  # noqa: E402
     TigramiteEffects,
     _to_tigramite_graph,
     tigramite_available,
@@ -177,7 +177,10 @@ def test_fit_required_before_effects():
 # pathwise_effects
 # ---------------------------------------------------------------------------
 
-from causalts.effects.tigramite_effects import _find_all_paths, pathwise_effects
+from causalts.effects.tigramite_effects import (  # noqa: E402
+    _find_all_paths,
+    pathwise_effects,
+)
 
 
 def test_find_all_paths_chain():


### PR DESCRIPTION
Makes the `lint` workflow green and meaningful, and removes redundant/noisy checks. No behavioral code changes — imports, formatting, and lint config only.

## python-lint
Previously failed at `black` (8 unformatted files), and `flake8` was misconfigured — the CLI passed `--ignore` (wiping black-compatible defaults) while the existing `[tool.flake8]` in `pyproject.toml` was silently ignored (flake8 doesn't read pyproject natively).

- **Single-source config in `pyproject.toml`** via `Flake8-pyproject`; CI now runs `black --check .` / `isort --check .` / `flake8 .`.
- **Black-compatible ignores** (`E203, E226, E501, W503`), exclude `build/dist/docs/experiments`, allow `F401` in `__init__.py` (public re-exports). This alone cleared ~75 spurious findings (50 were `E226` fighting black).
- **Fixed the genuine remainder** (no suppression-only): removed unused imports, dropped an unused local, renamed an ambiguous lambda var (`l`→`lag`), resolved the `GraceResult` forward-ref with a `TYPE_CHECKING` import, and tagged intentional post-`importorskip` / mid-file re-export imports with `# noqa: E402`.
- Ran `black` + `isort` across the tree.

## super-linter
It re-ran Python linters (redundant with python-lint) and three low-signal validators. Disabled: all `PYTHON_*`, plus `JSCPD` (copy-paste detector), `NATURAL_LANGUAGE` (prose), `MARKDOWN_PRETTIER` (competing md formatter). Kept markdownlint/yamllint/actions/shell.

## Verified locally
- `black`/`isort`/`flake8` all clean (reading pyproject)
- `import causalts` + every edited module imports; no runtime hint introspection of the forward-ref anywhere
- 128 tests collect; `test_synthetic_data.py` + `test_plotting.py` pass (18)
- `check_stationarity` removal confirmed safe (defined in `structural_causal_processes.py`; the dropped line was a dead re-import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)