### PR TITLE
docs: fix stale version in switcher and Sphinx release

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "v0.25 (stable)",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "url": "https://causal-ts.readthedocs.io/en/stable/",
     "preferred": true
   }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,12 +1,17 @@
 import os
 import sys
+from importlib.metadata import PackageNotFoundError, version
 
 sys.path.insert(0, os.path.abspath(".."))
 
 project = "Causal-TS"
 copyright = "2025-2026, Mohammad Fesanghary"
 author = "Mohammad Fesanghary"
-release = "0.14.0"
+# Derive the version from the installed package so it never goes stale.
+try:
+    release = version("causalts")
+except PackageNotFoundError:
+    release = "0.0.0"
 
 extensions = [
     "myst_nb",


### PR DESCRIPTION
## Summary
Two repo-side causes of the wrong version showing in the docs version switcher:

1. **`docs/conf.py`** hardcoded `release = "0.14.0"` while `pyproject.toml` was already at `0.25.1`. Since `version_match = release`, the switcher button rendered "0.14". Now derived from the installed package via `importlib.metadata.version("causalts")` (with a `0.0.0` fallback), so it tracks `pyproject.toml` and never goes stale again.
2. **`docs/_static/switcher.json`** still said `0.25.0`; bumped to `0.25.1` to match the current tag/release so the switcher entry highlights correctly.

## Note (not fixable from the repo)
RTD's `stable` version must be **rebuilt** on the readthedocs.org dashboard to pick these up — the current `stable` was last built from an older commit. Trigger a rebuild of `stable` (and `latest`) after merge.