### PR TITLE
Fix RTD build failure: conf.py version shadowing

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,7 @@
 import os
 import sys
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 sys.path.insert(0, os.path.abspath(".."))
 
@@ -8,10 +9,14 @@ project = "Causal-TS"
 copyright = "2025-2026, Mohammad Fesanghary"
 author = "Mohammad Fesanghary"
 # Derive the version from the installed package so it never goes stale.
+# NOTE: import the metadata helper under an alias — a bare ``version`` name
+# would shadow Sphinx's own ``version`` config value with a function object
+# and break the build (TypeError in inventory dump / smartquotes).
 try:
-    release = version("causalts")
+    release = _pkg_version("causalts")
 except PackageNotFoundError:
     release = "0.0.0"
+version = release
 
 extensions = [
     "myst_nb",


### PR DESCRIPTION
## Problem
The Read the Docs `latest` build fails at `sphinx-build` with:

```
File ".../sphinx/util/inventory.py", line 179, in escape
    return re.sub('\s+', ' ', string)
TypeError: expected string or bytes-like object, got 'function'
```

## Cause
PR #10 added `from importlib.metadata import PackageNotFoundError, version` to `docs/conf.py`. The bare name `version` shadows **Sphinx's own `version` config value** — so `config.version` became the `importlib.metadata.version` *function* instead of a string. Sphinx's inventory dump calls `escape(config.version)` → `re.sub(..., <function>)` → TypeError, aborting the build (exit 2).

## Fix
- Import the helper as `_pkg_version` (no longer shadows the config name).
- Set `version = release` explicitly so the `version` config is a plain string.

## Verification
Reproduced the exact failure locally (Python 3.12 venv, `pip install .[dowhy]` + `docs/requirements.txt`, `sphinx -T -b html`), then confirmed the patched `conf.py` builds cleanly: `build succeeded` with `dumping object inventory... done`.