### PR TITLE
ci: skip notebooks in codespell (base64 output false-positives)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+# codespell scans committed Jupyter notebooks, whose cells store executed
+# outputs as base64-encoded image blobs. codespell false-positives on random
+# substrings inside that base64 (e.g. "fO", "FPR", "jOO"). Example notebooks
+# are worked demos with saved outputs, not prose to spell-check, so skip them.
+[codespell]
+skip = *.ipynb

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,7 @@
-# codespell scans committed Jupyter notebooks, whose cells store executed
-# outputs as base64-encoded image blobs. codespell false-positives on random
-# substrings inside that base64 (e.g. "fO", "FPR", "jOO"). Example notebooks
-# are worked demos with saved outputs, not prose to spell-check, so skip them.
+# codespell scans changed files, including committed Jupyter notebooks whose
+# cells store executed outputs as base64-encoded image data. codespell reports
+# spurious matches on random substrings inside that encoded data and fails the
+# lint job on any pull request that touches a notebook. Example notebooks are
+# worked demos with saved outputs, not prose to spell-check, so skip them.
 [codespell]
 skip = *.ipynb


### PR DESCRIPTION
super-linter runs codespell on changed files. Example notebooks store executed cell outputs as base64-encoded PNG blobs; codespell false-positives on random substrings inside that base64 (e.g. 'fO', 'FPR', 'jOO'), failing the lint job on any PR that touches a notebook. Notebooks are worked demos with saved outputs, not prose to spell-check, so exclude them via .codespellrc.

# Description

Please provide a meaningful description of what this change will do, or is for.
Bonus points for including links to related issues, other PRs, or technical
references.

Note that by _not_ including a description, you are asking reviewers to do extra
work to understand the context of this change, which may lead to your PR taking
much longer to review, or result in it not being reviewed at all.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/bloomberg/causal-ts/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
