### PR TITLE
ci: disable super-linter PYTHON_RUFF_FORMAT (Python handled by black)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,6 +42,7 @@ jobs:
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_PYTHON_MYPY: false
           VALIDATE_PYTHON_RUFF: false
+          VALIDATE_PYTHON_RUFF_FORMAT: false
           VALIDATE_PYTHON_PYINK: false
           # Low-signal validators for a research codebase (copy-paste
           # detector, prose style, competing markdown formatter).


### PR DESCRIPTION
super-linter v8 splits ruff into PYTHON_RUFF (lint) and PYTHON_RUFF_FORMAT (format). The repo disables all super-linter Python validators because Python is formatted/linted by the dedicated python-lint (black) job, but RUFF_FORMAT was missed, so it flags any changed .py that black already accepts. Disable it for consistency with the rest of the Python validators.

# Description

Please provide a meaningful description of what this change will do, or is for.
Bonus points for including links to related issues, other PRs, or technical
references.

Note that by _not_ including a description, you are asking reviewers to do extra
work to understand the context of this change, which may lead to your PR taking
much longer to review, or result in it not being reviewed at all.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/bloomberg/causal-ts/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
