### PR TITLE
ci(docs): trigger Read the Docs via API v3 token, not incoming webhook

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,11 +3,11 @@ name: docs
 
 # Trigger a Read the Docs build on every push to main and every version tag.
 # Read the Docs is not connected via its GitHub App (org policy), so it does
-# not receive push/tag events on its own — this workflow pokes RTD's generic
-# incoming webhook instead. Configure the two secrets from the RTD dashboard:
-#   Admin -> Integrations -> Add integration -> "Incoming webhook"
-#   RTD_WEBHOOK_URL   the integration URL
-#   RTD_WEBHOOK_TOKEN the integration's secret token
+# not receive push/tag events on its own. This project's RTD account exposes
+# API tokens (not an "Incoming webhook" integration), so we call the RTD API v3
+# build endpoint directly. Configure one secret:
+#   RTD_TOKEN   a Read the Docs API token (RTD dashboard -> Settings -> Tokens)
+# and set RTD_PROJECT below to the project slug if it differs.
 on:
   push:
     branches:
@@ -30,16 +30,26 @@ jobs:
           egress-policy: audit
       - name: 📡 trigger Read the Docs build
         env:
-          RTD_WEBHOOK_URL: ${{ secrets.RTD_WEBHOOK_URL }}
-          RTD_WEBHOOK_TOKEN: ${{ secrets.RTD_WEBHOOK_TOKEN }}
+          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+          RTD_PROJECT: causal-ts
         run: |
-          if [ -z "${RTD_WEBHOOK_URL}" ] || [ -z "${RTD_WEBHOOK_TOKEN}" ]; then
-            echo "::error::RTD_WEBHOOK_URL / RTD_WEBHOOK_TOKEN secrets are not set."
+          if [ -z "${RTD_TOKEN}" ]; then
+            echo "::error::RTD_TOKEN secret is not set."
             exit 1
           fi
-          # A bare POST makes RTD sync versions and build the default version;
-          # this also picks up newly pushed tags so `stable` refreshes.
+          api="https://app.readthedocs.org/api/v3/projects/${RTD_PROJECT}/versions"
+          # Always rebuild the default version (tracks the main branch).
+          echo "Triggering Read the Docs build for 'latest'..."
           curl --fail-with-body --silent --show-error \
-            -X POST \
-            -d "token=${RTD_WEBHOOK_TOKEN}" \
-            "${RTD_WEBHOOK_URL}"
+            -X POST -H "Authorization: Token ${RTD_TOKEN}" \
+            "${api}/latest/builds/"
+          # On a version tag, also refresh 'stable' (RTD's stable tracks the
+          # highest tag). Best-effort: don't fail the job if that version is not
+          # active yet on RTD -- it just needs a one-time activation there.
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            echo "Tag push: also triggering 'stable' build (best-effort)..."
+            curl --fail-with-body --silent --show-error \
+              -X POST -H "Authorization: Token ${RTD_TOKEN}" \
+              "${api}/stable/builds/" \
+              || echo "::warning::Could not trigger 'stable' build; activate the version on RTD."
+          fi


### PR DESCRIPTION
This RTD account exposes API tokens rather than an 'Incoming webhook' integration, so the previous workflow failed on every push (RTD_WEBHOOK_URL / RTD_WEBHOOK_TOKEN never existed). Call the RTD API v3 build endpoint with a single RTD_TOKEN secret instead:
  POST https://app.readthedocs.org/api/v3/projects/<slug>/versions/<v>/builds/
  Authorization: Token <RTD_TOKEN>
Builds 'latest' on every push; on a version tag also best-effort builds 'stable'. Set the RTD_TOKEN repository secret and RTD_PROJECT if the slug differs from 'causal-ts'.

# Description

Please provide a meaningful description of what this change will do, or is for.
Bonus points for including links to related issues, other PRs, or technical
references.

Note that by _not_ including a description, you are asking reviewers to do extra
work to understand the context of this change, which may lead to your PR taking
much longer to review, or result in it not being reviewed at all.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/bloomberg/causal-ts/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
