### PR TITLE
perf(grace): batched-matmul gate aggregation (avoid ~17 GiB alloc at …

### DIFF
--- a/causalts/grace/gated_discovery.py
+++ b/causalts/grace/gated_discovery.py
@@ -625,12 +625,17 @@ class GatedCausalDiscovery(LightningModule):
         else:
             encoded = x.unsqueeze(-1) * self.W.unsqueeze(0) + self.bias.unsqueeze(0)
 
-        # Apply gates and aggregate: sum over (cause, lag) per effect
-        # gates: [cause, lag, effect] -> [1, cause, lag, effect, 1]
-        # encoded: [B, cause, lag, hidden] -> [B, cause, lag, 1, hidden]
-        x_hat = (encoded.unsqueeze(-2) * gates.unsqueeze(0).unsqueeze(-1)).sum(
-            dim=[1, 2]
-        )
+        # Apply gates and aggregate: sum over (cause, lag) per effect.
+        # Done as a batched matmul over the flattened (cause, lag) axis instead
+        # of a dense [B, cause, lag, effect, hidden] broadcast-then-sum: at
+        # d=300 the dense form allocates ~17 GiB (B * d^2 * (L+1) * H) for a
+        # tensor that is >99.5% masked out by the skeleton. matmul only ever
+        # materializes O(B * d * (L+1) * H) intermediates.
+        K = m * Lp1
+        encoded_flat = encoded.reshape(B, K, self.hidden_size)  # [B, K, H]
+        gates_flat = gates.reshape(K, m)  # [K, effect]
+        x_hat = torch.matmul(encoded_flat.transpose(1, 2), gates_flat)  # [B, H, effect]
+        x_hat = x_hat.transpose(1, 2)  # [B, effect, hidden]
         # x_hat: [B, effect, hidden]
 
         # Decode: per-effect independent decoders


### PR DESCRIPTION
…high d)

GatedCausalDiscovery aggregated gates via a dense
[B, cause, lag, effect, hidden] broadcast-then-sum, which at d=300 allocates ~17 GiB for a tensor >99.5% masked out by the skeleton. Replace with a batched matmul over the flattened (cause, lag) axis, materializing only O(B * d * (L+1) * H). Output-identical (verified numerically across shapes, contiguous and non-contiguous inputs); memory only.

# Description

Please provide a meaningful description of what this change will do, or is for.
Bonus points for including links to related issues, other PRs, or technical
references.

Note that by _not_ including a description, you are asking reviewers to do extra
work to understand the context of this change, which may lead to your PR taking
much longer to review, or result in it not being reviewed at all.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/bloomberg/causal-ts/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
