### PR TITLE
perf: lazy-load cedar.legacy, grace and statsmodels

### DIFF
--- a/causalts/__init__.py
+++ b/causalts/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from importlib.metadata import PackageNotFoundError, version
+from typing import TYPE_CHECKING
 
 try:
     __version__ = version("causalts")
@@ -19,18 +20,12 @@ from .cdnots.phase3_utils import (  # deprecated — use run_cdnots  # noqa: F40
 )
 from .cdnots.result import CdnotsResult  # noqa: F401
 from .cedar.discovery import Cedar, run_cedar  # noqa: F401
-from .cedar.legacy import SYPI  # noqa: F401
 from .cedar.result import CedarResult  # noqa: F401
 from .feature_selection import (  # noqa: F401
     Feature,
     FeatureSelectionResult,
     select_features,
 )
-from .grace.gated_discovery import (  # noqa: F401
-    run_cdnots_gated,
-    run_stability_selection,
-)
-from .grace.result import GraceResult  # noqa: F401
 from .inspection import discover_df, inspect_df, recommend_config  # noqa: F401
 from .result import CausalResult  # noqa: F401
 from .tigramite_discovery import (  # noqa: F401
@@ -38,4 +33,54 @@ from .tigramite_discovery import (  # noqa: F401
     run_pcmci,
     run_pcmciplus,
     run_tigramite,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checkers only
+    from .cedar.legacy import SYPI  # noqa: F401
+    from .grace.gated_discovery import (  # noqa: F401
+        run_cdnots_gated,
+        run_stability_selection,
+    )
+    from .grace.result import GraceResult  # noqa: F401
+
+# Served on demand so that ``import causalts`` stays cheap: cedar.legacy pulls
+# in dcor + statsmodels, grace pulls in pytorch-lightning, and neither is on the
+# common discovery path.  Maps attribute name -> module that defines it.
+_LAZY_ATTRS = {
+    "SYPI": "causalts.cedar.legacy",
+    "run_cdnots_gated": "causalts.grace.gated_discovery",
+    "run_stability_selection": "causalts.grace.gated_discovery",
+    "GraceResult": "causalts.grace.result",
+}
+
+# Subpackages that used to be bound as attributes of ``causalts`` as a side
+# effect of the eager imports above.  Keeps ``causalts.grace`` and
+# ``causalts.plotting`` resolving without importing them up front.
+_LAZY_SUBMODULES = ("grace", "plotting")
+
+
+def __getattr__(name):
+    """Import a lazily-exposed attribute or subpackage on first access (PEP 562)."""
+    import importlib
+
+    if name in _LAZY_SUBMODULES:
+        value = importlib.import_module(f"{__name__}.{name}")
+    elif name in _LAZY_ATTRS:
+        value = getattr(importlib.import_module(_LAZY_ATTRS[name]), name)
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    globals()[name] = value  # cache so __getattr__ only runs once per name
+    return value
+
+
+def __dir__():
+    return sorted(__all__)
+
+
+# Explicit __all__ so that ``from causalts import *`` still exports the lazy
+# names; star-import consults __all__ and never triggers __getattr__ without it.
+__all__ = sorted(
+    ({name for name in globals() if not name.startswith("_")} - {"TYPE_CHECKING"})
+    | set(_LAZY_ATTRS)
+    | set(_LAZY_SUBMODULES)
 )

--- a/causalts/algorithms/__init__.py
+++ b/causalts/algorithms/__init__.py
@@ -20,6 +20,26 @@ from __future__ import annotations
 
 _ALGO_REGISTRY: dict[str, callable] = {}
 
+# Algorithms whose module is expensive to import (GRACE pulls in
+# pytorch-lightning) are registered lazily: name -> (module path, function).
+# ``causalts.grace`` used to self-register at import time; registering here
+# keeps the names listed without paying for the import.  Mirrors the
+# _LAZY_REGISTRY pattern in causalts.ci_tests.
+_LAZY_ALGO_REGISTRY: dict[str, tuple[str, str]] = {
+    "grace": ("causalts.grace.gated_discovery", "run_cdnots_gated"),
+    "grace-ss": ("causalts.grace.gated_discovery", "run_stability_selection"),
+}
+
+
+def _resolve_lazy(name: str):
+    """Import a lazily-registered algorithm and cache it in the registry."""
+    import importlib
+
+    module_path, fn_name = _LAZY_ALGO_REGISTRY[name]
+    fn = getattr(importlib.import_module(module_path), fn_name)
+    _ALGO_REGISTRY[name] = fn
+    return fn
+
 
 def register_algorithm(name: str):
     """Decorator to register a discovery function under *name*.
@@ -45,7 +65,7 @@ def register_algorithm(name: str):
 
 def list_algorithms() -> list[str]:
     """Return sorted list of all registered algorithm names."""
-    return sorted(_ALGO_REGISTRY)
+    return sorted(set(_ALGO_REGISTRY) | set(_LAZY_ALGO_REGISTRY))
 
 
 def run_algorithm(name: str, df, ci_test, max_lag, **kwargs):
@@ -69,5 +89,10 @@ def run_algorithm(name: str, df, ci_test, max_lag, **kwargs):
     CausalResult
     """
     if name not in _ALGO_REGISTRY:
-        raise ValueError(f"Unknown algorithm {name!r}. Available: {list_algorithms()}")
+        if name in _LAZY_ALGO_REGISTRY:
+            _resolve_lazy(name)
+        else:
+            raise ValueError(
+                f"Unknown algorithm {name!r}. Available: {list_algorithms()}"
+            )
     return _ALGO_REGISTRY[name](df=df, ci_test=ci_test, max_lag=max_lag, **kwargs)

--- a/causalts/cedar/__init__.py
+++ b/causalts/cedar/__init__.py
@@ -1,6 +1,38 @@
 # Copyright 2025 Bloomberg Finance L.P.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from typing import TYPE_CHECKING
+
 from .discovery import Cedar, run_cedar  # noqa: F401
-from .legacy import SYPI  # noqa: F401  # deprecated — use run_cedar / Cedar
 from .result import CedarResult  # noqa: F401
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checkers only
+    from .legacy import SYPI  # noqa: F401
+
+
+def __getattr__(name):
+    """Serve the deprecated SYPI shim, and its module, on demand.
+
+    ``legacy`` imports dcor + statsmodels, which is a large share of the cost of
+    ``import causalts``; nothing on the Cedar path needs it.
+    """
+    import importlib
+
+    if name == "legacy":
+        value = importlib.import_module(f"{__name__}.legacy")
+    elif name == "SYPI":  # deprecated — use run_cedar / Cedar
+        value = importlib.import_module(f"{__name__}.legacy").SYPI
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(__all__)
+
+
+__all__ = sorted(
+    ({name for name in globals() if not name.startswith("_")} - {"TYPE_CHECKING"})
+    | {"SYPI", "legacy"}
+)

--- a/causalts/utils/linearity.py
+++ b/causalts/utils/linearity.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import numpy as np
-import statsmodels.api as sm
-from statsmodels.stats.diagnostic import linear_reset
 
 
 def check_linearity(data, alpha=0.05, max_lag=1, pairs=None):
@@ -39,6 +37,11 @@ def check_linearity(data, alpha=0.05, max_lag=1, pairs=None):
         - fraction_nonlinear: fraction of tests rejecting linearity
         - summary: human-readable recommendation string
     """
+    # Imported here rather than at module scope: statsmodels costs ~0.25s to
+    # import and this is the only thing in causalts that needs it eagerly.
+    import statsmodels.api as sm
+    from statsmodels.stats.diagnostic import linear_reset
+
     if hasattr(data, "values"):
         data = data.values
     data = np.asarray(data, dtype=np.float64)

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,0 +1,114 @@
+# Copyright 2025 Bloomberg Finance L.P.
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Guard the lazy-import surface.
+
+``causalts.cedar.legacy`` (dcor, statsmodels) and ``causalts.grace``
+(pytorch-lightning) are imported on demand to keep ``import causalts`` fast.
+These tests pin both halves of that contract: the heavy modules stay unimported,
+and every public name still resolves through every import form.
+
+Laziness assertions must run in a fresh interpreter -- sibling test modules
+import grace/legacy, which would pollute ``sys.modules`` in-process.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+# "statsmodels" (the bare package), not just "statsmodels.api": the aggregator
+# can stay unimported while a submodule import -- e.g. multivariate.cancorr --
+# still drags the core package onto the import path.
+HEAVY = ["dcor", "pytorch_lightning", "statsmodels"]
+LAZY_MODULES = ["causalts.cedar.legacy", "causalts.grace"]
+LAZY_NAMES = ["SYPI", "run_cdnots_gated", "run_stability_selection", "GraceResult"]
+
+
+def _run(code):
+    """Execute *code* in a clean interpreter, return stdout."""
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=False
+    )
+    assert out.returncode == 0, out.stderr
+    return out.stdout.strip()
+
+
+@pytest.mark.parametrize("mod", HEAVY + LAZY_MODULES)
+def test_heavy_module_not_imported_eagerly(mod):
+    """A plain ``import causalts`` must not drag in the expensive deps."""
+    loaded = _run(f"import sys, causalts; print({mod!r} in sys.modules)")
+    assert loaded == "False", f"{mod} was imported eagerly by `import causalts`"
+
+
+@pytest.mark.parametrize("name", LAZY_NAMES)
+def test_lazy_name_resolves_by_attribute(name):
+    assert _run(f"import causalts; print(causalts.{name}.__name__)")
+
+
+@pytest.mark.parametrize("name", LAZY_NAMES)
+def test_lazy_name_resolves_by_from_import(name):
+    assert _run(f"from causalts import {name}; print({name}.__name__)")
+
+
+@pytest.mark.parametrize("name", LAZY_NAMES)
+def test_lazy_name_exported_by_star_import(name):
+    """Regression: __getattr__ alone does not feed ``from causalts import *``."""
+    assert _run(f"exec('from causalts import *'); print({name}.__name__)")
+
+
+@pytest.mark.parametrize("sub", ["grace", "plotting", "cedar"])
+def test_submodule_attribute_access(sub):
+    """Regression: eager imports used to bind these as package attributes."""
+    assert _run(f"import causalts; print(causalts.{sub}.__name__)") == f"causalts.{sub}"
+
+
+def test_cedar_legacy_attribute_access():
+    assert (
+        _run("import causalts; print(causalts.cedar.legacy.__name__)")
+        == "causalts.cedar.legacy"
+    )
+
+
+def test_direct_submodule_import_still_works():
+    assert _run("import causalts.grace.gated_discovery as g; print(g.__name__)")
+
+
+def test_import_submodule_before_package():
+    """Importing a lazy submodule first must not deadlock or double-register."""
+    assert _run(
+        "import causalts.grace; import causalts; "
+        "from causalts.algorithms import list_algorithms; print(list_algorithms())"
+    )
+
+
+def test_grace_registered_without_importing_lightning():
+    """The registry lists grace lazily; listing must not pay the import cost."""
+    out = _run(
+        "import sys; from causalts.algorithms import list_algorithms; "
+        "names = list_algorithms(); "
+        "print(('grace' in names) and ('grace-ss' in names), "
+        "'pytorch_lightning' in sys.modules)"
+    )
+    assert out == "True False"
+
+
+def test_unknown_attribute_raises_attribute_error():
+    import causalts
+
+    with pytest.raises(AttributeError, match="has no attribute"):
+        causalts.definitely_not_a_thing
+
+
+def test_unknown_algorithm_still_raises_value_error():
+    from causalts.algorithms import run_algorithm
+
+    with pytest.raises(ValueError, match="Unknown algorithm"):
+        run_algorithm("bogus", None, None, 1)
+
+
+def test_dir_lists_lazy_names():
+    import causalts
+
+    listed = dir(causalts)
+    for name in LAZY_NAMES + ["grace"]:
+        assert name in listed, f"{name} missing from dir(causalts)"


### PR DESCRIPTION
## What

`import causalts` took **~4.5 s**, roughly half of it spent importing modules the common discovery path never touches. This defers three of them, cutting import time to **~2.05 s**.

| | import time |
|---|---|
| `main` | 4.48 / 4.53 / 4.53 s |
| this branch | 2.05 / 2.05 / 2.08 s |

(paired, alternating runs on one machine; `causal-ts --help` improves by the same amount)

The deferred imports:

- **`causalts.cedar.legacy`** — the deprecated `SYPI` shim, which pulls in `dcor` → `numba`/`llvmlite`
- **`causalts.grace`** — pulls in `pytorch-lightning` → `torch._dynamo`
- **`statsmodels.api`** in `utils/linearity.py` — the one module-scope statsmodels import left; every other use in the package is already function-level

The remaining ~2 s is `torch` and `causal-learn`, which the `cdnots` and `cedar` paths genuinely need.

## Why it's more than a `__getattr__`

Three things break if you only add PEP 562 `__getattr__` to the two `__init__.py` files — all silent, none raising at import time:

1. **`causalts.grace` and `causalts.plotting` stop resolving.** They were bound as package attributes only as a *side effect* of the eager imports. Restored via `_LAZY_SUBMODULES`.
2. **`from causalts import *` silently stops exporting `SYPI`, `run_cdnots_gated`, `GraceResult`.** Star-import consults `__all__` and never triggers `__getattr__`, so `__all__` is now explicit.
3. **`--algorithm grace` becomes an invalid CLI choice.** `grace/__init__.py` self-registers `grace`/`grace-ss` at import time, feeding `list_algorithms()` → `cli.ALGORITHM_CHOICES`. A `_LAZY_ALGO_REGISTRY` — mirroring the existing `_LAZY_REGISTRY` in `causalts.ci_tests` — keeps both listed and resolves them on first use. Registration stays idempotent: `grace/__init__.py` still self-registers on direct import, writing the same entry.

`TYPE_CHECKING` blocks keep the lazy names resolvable for type checkers and IDEs, and are subtracted from `__all__`.

## Testing

- **Existing suite unchanged:** 210 passed, 2 skipped — identical before and after.
- **New `tests/test_lazy_imports.py`** (27 tests): asserts the heavy modules stay unimported, and that every public name still resolves via attribute access, from-import, star-import, submodule attribute, and direct submodule import; plus registry listing without loading lightning, import-ordering, and both error paths. The laziness assertions run in **subprocesses** — sibling test modules import grace and legacy, so an in-process `sys.modules` check would pass vacuously depending on collection order.
- **Mutation-checked:** against `main` these tests produce 6 failures (exactly the laziness ones); an earlier draft of this change that lacked `__all__`/`_LAZY_SUBMODULES` produced 8 (exactly the star-import and submodule ones). They fail for the reasons they exist.
- **API-surface diff** over 84 modules — every public name of every submodule, `dir()`, star-import contents, `list_algorithms()`, `list_ci_tests()` — captured on `main` and re-diffed here: **1 entry differs**, `causalts.utils.linearity` no longer exposing `sm`/`linear_reset` as module attributes. That is the intended consequence of moving the import into the function; it was never public API. This diff is what caught the `plotting` regression above.
- **Lint:** `black --check .`, `isort --check .`, `flake8 .` and codespell all clean.

## Not verified

- Docs build — autodoc now resolves members through the new `__all__`; worth a look at whether `SYPI`/`GraceResult` entries still render.
- Only exercised on Python 3.14 locally; CI covers the rest of the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)