### PR TITLE
docs: note that corrplot diag="glyph" leaves a split diagonal blank

### DIFF
--- a/causalts/plotting/corrplot.py
+++ b/causalts/plotting/corrplot.py
@@ -255,7 +255,9 @@ def corrplot(
         cause→effect adjacency or edge-stability matrix) where the diagonal
         is real data — a self-loop — rather than the trivial 1.0 of a
         correlation matrix. Significance markers and confidence-interval
-        overlays are still skipped on the diagonal.
+        overlays are still skipped on the diagonal. With an upper/lower split
+        the diagonal is left blank instead: it belongs to neither half, so
+        there is no "ordinary cell" method to borrow.
     is_corr : bool or None
         If None, auto-detect whether data is correlation-like ([-1, 1]).
         If True, force [-1, 1] range with diverging cmap.

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -187,6 +187,35 @@ def test_corrplot_diag_glyph_renders_the_diagonal():
     assert with_diag == without + n
 
 
+def test_corrplot_diag_glyph_leaves_split_diagonal_blank():
+    """With an upper/lower split, diag="glyph" draws nothing on the diagonal.
+
+    Documented behaviour, not an oversight: a diagonal cell belongs to neither
+    half, so there is no method to borrow. Pinned so the blank diagonal cannot
+    turn into an arbitrary one (e.g. silently falling back to `method`, which
+    the caller never set when upper/lower are given).
+    """
+    import matplotlib.pyplot as plt
+
+    from causalts.plotting import corrplot
+
+    counts = {}
+    for diag in ("blank", "glyph"):
+        fig, ax = plt.subplots()
+        corrplot(
+            _make_frame(),
+            upper="circle",
+            lower="color",
+            diag=diag,
+            colorbar=False,
+            fig_ax=(fig, ax),
+        )
+        counts[diag] = _glyph_path_count(ax)
+        plt.close(fig)
+
+    assert counts["glyph"] == counts["blank"]
+
+
 def test_corrplot_grid_border_is_closed():
     """All four edges of the grid border must be drawn.
 


### PR DESCRIPTION
`diag="glyph"` documents itself as drawing the diagonal "as an ordinary cell", which does not hold when both `upper` and `lower` are set: a diagonal cell belongs to neither half, so `_cell_method` returns `None` and the cell is skipped entirely.

Documenting rather than changing the behaviour — there is no correct method to borrow for a split diagonal, and falling back to `method` would render it with a parameter the caller never set (it stays at its `"circle"` default whenever `upper`/`lower` are given), so the diagonal would clash with both halves.

Adds a test pinning the blank diagonal, verified to fail if the fallback is introduced.
