### PR TITLE
fix: reject collider priority 3 and 4 instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+* `priority=3` and `priority=4` (collider strength ordering) now raise `ValueError`
+  at the entry point, instead of failing with an `AttributeError` from inside
+  causal-learn after the skeleton search. They score each conflict over the full
+  powerset of the endpoints' neighbours — exponential in node degree — and were
+  never wired to a CI test. Use `priority=1` (abstain) or `2` (keep first).
 * `detect_subsampling` raises `ValueError` on a 1-D or single-variable input, instead of
   failing inside NumPy with `LinAlgError: 0-dimensional array given`.
 

--- a/causalts/cdnots/phase3_utils.py
+++ b/causalts/cdnots/phase3_utils.py
@@ -25,7 +25,7 @@ from .skeleton_discovery import (
     skeleton_discovery,
     skeleton_discovery_pervar,
 )
-from .uc_sepset import uc_sepset
+from .uc_sepset import uc_sepset, validate_priority
 
 _C_PRESETS = {
     "linear": lambda T: np.arange(T, dtype=float).reshape(-1, 1),
@@ -837,7 +837,8 @@ def run_cdnots(
     max_combinations : int
         Maximum conditioning sets per edge per depth.
     priority : int
-        Collider conflict resolution strategy (0-4).
+        Collider conflict resolution strategy: 0 (overwrite),
+        1 (abstain on conflicts) or 2 (keep the first collider).
     verbose : bool
         Print CI test results.
     show_progress : bool
@@ -870,6 +871,7 @@ def run_cdnots(
         Self-contained result with graph, p-values, plotting, and
         effect-estimation methods.
     """
+    validate_priority(priority)
     disc_out = cdnots_discovery(
         df=df,
         indep_test=indep_test,
@@ -995,6 +997,7 @@ def run_cdnots_plus(
     CdnotsResult
         Self-contained result.
     """
+    validate_priority(priority)
     if discrete_cols is None:
         discrete_cols = _detect_discrete_cols(df, df.shape[0])
 

--- a/causalts/cdnots/uc_sepset.py
+++ b/causalts/cdnots/uc_sepset.py
@@ -19,6 +19,36 @@ from causallearn.utils.PCUtils.Helper import sort_dict_ascending
 from causalts.cdnots.meek import _build_adj_dict, _find_unshielded_triples_fast
 
 
+def validate_priority(priority: int) -> None:
+    """Reject collider-conflict rules CDNOTS does not support.
+
+    Call this at an entry point, before the skeleton search -- the check below
+    in :func:`uc_sepset` only runs after it, so on its own it would let a bad
+    value burn the whole search first.
+    """
+    if priority in (0, 1, 2):
+        return
+    if priority in (3, 4):
+        # Upstream's strength-ordering rules. They score every conflicting
+        # triple by max p(x indep z | S) over find_cond_sets(), which is the
+        # full powerset of the neighbours of x and z -- 2**degree conditioning
+        # sets per triple, uncapped, on top of a skeleton search that
+        # deliberately stopped at the first separating set. They also need
+        # cg.ci_test, which CDNOTS never wires up, so they used to fail with an
+        # opaque AttributeError from inside causal-learn. Rejected explicitly
+        # instead: CDNOTS+ abstains on conflicts (priority=1) rather than
+        # tie-breaking them.
+        raise ValueError(
+            f"priority={priority} (collider strength ordering) is not "
+            "supported: it scores each conflict over the full powerset of "
+            "the endpoints' neighbours, which is exponential in the node "
+            "degree. Use priority=1 to abstain on conflicts (CDNOTS+'s "
+            "default) or priority=2 to keep the first collider "
+            "(CDNOTS's default)."
+        )
+    raise ValueError(f"priority must be 0, 1 or 2, got {priority!r}")
+
+
 def uc_sepset(
     cg: CausalGraph,
     priority: int = 2,
@@ -38,9 +68,12 @@ def uc_sepset(
         A CausalGraph object.
     priority : int
         Rule of resolving conflicts between unshielded colliders
-        (default 2). 0: overwrite, 1: orient bi-directed,
-        2: prioritize existing colliders, 3: prioritize stronger
-        colliders, 4: prioritize stronger* colliders.
+        (default 2). 0: overwrite, 1: orient bi-directed (abstain --
+        CDNOTS+'s default), 2: prioritize existing colliders
+        (CDNOTS's default). Upstream's 3 and 4 (strength ordering)
+        are **not supported** and raise ``ValueError``; they are
+        exponential in the node degree. See ``maxp`` below, which
+        retains them but is not reachable from CDNOTS.
     background_knowledge : BackgroundKnowledge, optional
         Artificial background knowledge.
     num_lags : int
@@ -69,7 +102,7 @@ def uc_sepset(
         ``graph[i,j] = graph[j,i] = 1`` indicates i <-> j.
     """
 
-    assert priority in [0, 1, 2, 3, 4]
+    validate_priority(priority)
 
     no_of_var = cg.G.num_vars
     assert no_of_var % (num_lags + 1) == 0

--- a/tests/test_uc_sepset_priority1.py
+++ b/tests/test_uc_sepset_priority1.py
@@ -171,3 +171,72 @@ def test_keep_undirected_survives_bidirected_branch():
 
 if __name__ == "__main__":
     pytest.main([__file__])
+
+
+@pytest.mark.parametrize("priority", [3, 4])
+def test_strength_ordering_priorities_are_rejected(priority):
+    """priority=3/4 must fail fast with an explanation, not an AttributeError.
+
+    Upstream's strength-ordering rules score every conflicting triple over
+    ``find_cond_sets()`` -- the full powerset of the endpoints' neighbours,
+    uncapped, so exponential in node degree. They also call ``cg.ci_test``,
+    which CDNOTS never wires up, so they used to die with
+    ``AttributeError: 'NoneType' object has no attribute 'method'`` from
+    inside causal-learn after the skeleton search had already run.
+    """
+    ci = ParCorrGPU(np.zeros((2, 2)), device="cpu")
+    with pytest.raises(ValueError, match="not supported"):
+        run_cdnots(
+            _data(T=200),
+            ci,
+            num_lags=1,
+            include_C=False,
+            priority=priority,
+            verbose=False,
+            show_progress=False,
+        )
+
+
+def test_out_of_range_priority_is_rejected():
+    ci = ParCorrGPU(np.zeros((2, 2)), device="cpu")
+    with pytest.raises(ValueError, match="priority must be 0, 1 or 2"):
+        run_cdnots(
+            _data(T=200),
+            ci,
+            num_lags=1,
+            include_C=False,
+            priority=7,
+            verbose=False,
+            show_progress=False,
+        )
+
+
+@pytest.mark.parametrize("entry", ["run_cdnots", "run_cdnots_plus"])
+@pytest.mark.parametrize("priority", [3, 4])
+def test_bad_priority_rejected_before_the_skeleton_search(entry, priority, monkeypatch):
+    """The point of the check is fail-fast, not just the exception type.
+
+    uc_sepset runs *after* skeleton discovery, so a guard there alone still
+    burns the whole search -- exactly where the old AttributeError fired.
+    """
+    import causalts.cdnots.phase3_utils as p3
+
+    calls = []
+    for name in ("skeleton_discovery", "skeleton_discovery_pervar"):
+        original = getattr(p3, name)
+        monkeypatch.setattr(
+            p3, name, lambda *a, _o=original, **k: (calls.append(1), _o(*a, **k))[1]
+        )
+
+    fn = getattr(p3, entry)
+    with pytest.raises(ValueError, match="not supported"):
+        fn(
+            _data(T=200),
+            ParCorrGPU(np.zeros((2, 2)), device="cpu"),
+            num_lags=1,
+            include_C=False,
+            priority=priority,
+            verbose=False,
+            show_progress=False,
+        )
+    assert calls == [], "skeleton search ran before the priority was rejected"


### PR DESCRIPTION
`priority=3/4` crashed with an `AttributeError` from causal-learn after the skeleton search had run. The ordering logic is mostly there, but it needs extra CI tests we don't currently support — so they're now rejected at the entry point instead. Use `priority=1` (abstain) or `2` (keep first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)