### PR TITLE
fix(cli): honor ci-test-info test selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+* `causal-ts ci-test-info --test <name>` now shows only the selected test's
+  summary instead of the full guide. Registered tests without a guide section
+  report a clear error; the default and `--test all` output are unchanged.
 * `priority=3` and `priority=4` (collider strength ordering) now raise `ValueError`
   at the entry point, instead of failing with an `AttributeError` from inside
   causal-learn after the skeleton search. They score each conflict over the full

--- a/causalts/cli.py
+++ b/causalts/cli.py
@@ -175,7 +175,16 @@ def main(ctx, output_dir, seed, device, verbose, quiet):
 )
 def ci_test_info(test):
     """Print the CI test selection guide and per-test summaries."""
-    click.echo(CI_TEST_GUIDE)
+    if test == "all":
+        click.echo(CI_TEST_GUIDE)
+        return
+
+    for section in CI_TEST_GUIDE.split("\n\n"):
+        if section.startswith(f"  {test} "):
+            click.echo(section)
+            return
+
+    raise click.ClickException(f"No selection guide available for CI test '{test}'.")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,16 +5,65 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 from click.testing import CliRunner
 
-from causalts.cli import main
+from causalts.cli import CI_TEST_CHOICES, CI_TEST_GUIDE, main
 
 
-def test_ci_test_info():
+@pytest.mark.parametrize("options", [[], ["--test", "all"]])
+def test_ci_test_info(options):
     runner = CliRunner()
-    result = runner.invoke(main, ["ci-test-info"])
+    result = runner.invoke(main, ["ci-test-info", *options])
     assert result.exit_code == 0
-    assert "parcorr" in result.output.lower()
+    assert result.output == CI_TEST_GUIDE + "\n"
+
+
+@pytest.mark.parametrize(
+    "test_name, last_line",
+    [
+        ("parcorr-gpu", "Works at any T and any d. Misses nonlinear edges."),
+        ("gcmi", "(monotone) nonlinearity only; misses non-monotone dependencies."),
+        ("kci", "Most general kernel test. O(T^3) — slow at large T."),
+        ("splitkci", "data. Performance improves with larger T."),
+        ("dfcit", "columns natively. Results vary by graph structure."),
+        ("rcot", "Fast. At T<=300, auto-averages 5 RFF draws to reduce variance."),
+        (
+            "cmiknn-gpu",
+            "Sensitive to many dependency types but slow (O(T^2) k-NN search).",
+        ),
+        ("sigkci", "Captures temporal structure that pointwise tests ignore."),
+    ],
+)
+def test_ci_test_info_filters_summary(test_name, last_line):
+    result = CliRunner().invoke(main, ["ci-test-info", "--test", test_name])
+
+    assert result.exit_code == 0
+    assert result.output.rstrip().endswith(last_line)
+    headings = [
+        name
+        for name in CI_TEST_CHOICES
+        if any(line.startswith(f"  {name} ") for line in result.output.splitlines())
+    ]
+    assert headings == [test_name]
+    assert "When to use what" not in result.output
+    assert "Key tradeoffs" not in result.output
+
+
+@pytest.mark.parametrize("test_name", ["cmiknn", "parcorr"])
+def test_ci_test_info_missing_summary(test_name):
+    result = CliRunner().invoke(main, ["ci-test-info", "--test", test_name])
+
+    assert result.exit_code == 1
+    assert f"No selection guide available for CI test '{test_name}'." in result.output
+    assert "Conditional Independence Test Selection Guide" not in result.output
+
+
+def test_ci_test_info_invalid_choice():
+    result = CliRunner().invoke(main, ["ci-test-info", "--test", "unknown"])
+
+    assert result.exit_code == 2
+    assert "Invalid value for '--test'" in result.output
 
 
 def test_generate_ex1(tmp_path):


### PR DESCRIPTION
# Description

Make `causal-ts ci-test-info --test <name>` print only the selected test's
summary instead of silently ignoring the option.

Closes #48.

- Match the exact section heading, keeping all continuation lines and avoiding
  prefix collisions such as `cmiknn` / `cmiknn-gpu`.
- Preserve the existing full output for both the default and `--test all`.
- Report a clear Click error when a registered test has no guide section, rather
  than returning an empty or unrelated summary.
- Cover all eight documented summaries, default/all compatibility, missing
  summaries, and invalid options; add an Unreleased changelog entry.

Validation (macOS, Python 3.12, core/development dependencies):

- Regression check before the fix: 10 failing selection cases, 3 passing cases.
- `python -m pytest tests/test_cli.py -q`: 16 passed.
- `python -m pytest tests/ -q --tb=short`: 399 passed, 2 skipped.
- `black --check .`: 127 Python files unchanged (notebooks not checked).
- `isort --check .` and `flake8 .`: passed.
- Manually verified the installed `causal-ts ci-test-info --test gcmi` command
  prints only the three-line GCMI summary.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/bloomberg/causal-ts/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
