### PR TITLE
docs: cover all registered CI tests in the selection guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 * `causal-ts ci-test-info --test <name>` now shows only the selected test's
   summary instead of the full guide. Registered tests without a guide section
   report a clear error; the default and `--test all` output are unchanged.
+* The CI test selection guide now covers all registered tests. `parcorr`,
+  `cmiknn`, `cmiknn-mixed-gpu`, `fisherz`, `chisq` and `gsquared` had no entry,
+  so `ci-test-info --test <name>` failed for them. The `cmiknn-gpu` entry also
+  now notes that its permutation null stops early.
 * `priority=3` and `priority=4` (collider strength ordering) now raise `ValueError`
   at the entry point, instead of failing with an `AttributeError` from inside
   causal-learn after the skeleton search. They score each conflict over the full

--- a/causalts/cli.py
+++ b/causalts/cli.py
@@ -45,9 +45,30 @@ Conditional Independence Test Selection Guide
 
   cmiknn-gpu   k-NN conditional mutual information. Nonparametric, no bandwidth.
                Sensitive to many dependency types but slow (O(T^2) k-NN search).
+               The permutation null stops early once the p-value is decided.
 
   sigkci       Signature kernel CI for path-valued data (SDEs, diffusions).
                Captures temporal structure that pointwise tests ignore.
+
+  cmiknn-mixed-gpu  k-NN CMI for mixed discrete-continuous data, using MSinf
+               stratification so k-NN balls never cross discrete values. Use
+               when some columns are categorical and others continuous.
+
+  parcorr      CPU partial correlation (tigramite implementation). Same
+               estimator as parcorr-gpu; use when torch is unavailable.
+
+  cmiknn       CPU k-NN conditional mutual information (tigramite
+               implementation, with early stopping). Same estimator as
+               cmiknn-gpu but markedly slower.
+
+  fisherz      Gaussian Fisher-Z test (causal-learn adapter). Analytic p-value,
+               same normality assumption as parcorr-gpu.
+
+  chisq        Chi-squared test for categorical data (causal-learn adapter).
+               All columns must be discrete. Reports a p-value only.
+
+  gsquared     G-squared / likelihood-ratio test for categorical data
+               (causal-learn adapter). All columns must be discrete.
 
 When to use what
 ----------------
@@ -57,7 +78,10 @@ When to use what
   Nonlinear, high collinearity     -> kci (uses all data, most robust)
   Monotone nonlinear, fast needed  -> gcmi (analytic, near-instant)
   Stochastic processes / SDEs      -> sigkci
+  All columns categorical          -> chisq or gsquared
+  Mixed discrete and continuous    -> dfcit, then cmiknn-mixed-gpu
   Runtime-constrained              -> parcorr-gpu or gcmi
+  No GPU / torch unavailable       -> parcorr or cmiknn (CPU implementations)
 
 Key tradeoffs
 -------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,7 @@ def test_ci_test_info(options):
         ("rcot", "Fast. At T<=300, auto-averages 5 RFF draws to reduce variance."),
         (
             "cmiknn-gpu",
-            "Sensitive to many dependency types but slow (O(T^2) k-NN search).",
+            "The permutation null stops early once the p-value is decided.",
         ),
         ("sigkci", "Captures temporal structure that pointwise tests ignore."),
     ],
@@ -50,13 +50,29 @@ def test_ci_test_info_filters_summary(test_name, last_line):
     assert "Key tradeoffs" not in result.output
 
 
-@pytest.mark.parametrize("test_name", ["cmiknn", "parcorr"])
-def test_ci_test_info_missing_summary(test_name):
+def test_every_registered_ci_test_has_a_guide_section():
+    """A CI test registered without a guide section makes --test <name> fail."""
+    sections = CI_TEST_GUIDE.split("\n\n")
+    missing = [
+        name
+        for name in CI_TEST_CHOICES
+        if not any(section.startswith(f"  {name} ") for section in sections)
+    ]
+    assert missing == []
+
+
+@pytest.mark.parametrize("test_name", CI_TEST_CHOICES)
+def test_ci_test_info_selects_every_registered_test(test_name):
     result = CliRunner().invoke(main, ["ci-test-info", "--test", test_name])
 
-    assert result.exit_code == 1
-    assert f"No selection guide available for CI test '{test_name}'." in result.output
-    assert "Conditional Independence Test Selection Guide" not in result.output
+    assert result.exit_code == 0
+    headings = [
+        name
+        for name in CI_TEST_CHOICES
+        if any(line.startswith(f"  {name} ") for line in result.output.splitlines())
+    ]
+    assert headings == [test_name]
+    assert "When to use what" not in result.output
 
 
 def test_ci_test_info_invalid_choice():


### PR DESCRIPTION
# Description

`CI_TEST_GUIDE` documented 8 of the 14 registered CI tests. After #49 made
`--test <name>` honour the selection, the six undocumented tests — `parcorr`,
`cmiknn`, `cmiknn-mixed-gpu`, `fisherz`, `chisq`, `gsquared` — exited 1 with
"No selection guide available". They are all valid `--ci-test` values.

This adds an entry for each, so every registered test resolves.

- `parcorr` / `cmiknn` are the CPU counterparts of documented GPU tests, so their
  entries point at those rather than repeating the description.
- `fisherz` / `chisq` / `gsquared` are noted as causal-learn adapters, and the
  categorical ones as requiring discrete columns.
- Adds routing lines to "When to use what" for the categorical, mixed and
  no-GPU cases, which had no guidance.
- Notes on the existing `cmiknn-gpu` entry that its permutation null stops early
  — previously undocumented, and it affects p-value semantics.

Replaces `test_ci_test_info_missing_summary` (which asserted the old failure for
`cmiknn`/`parcorr`) with a coverage test asserting every `CI_TEST_CHOICES` entry
has a guide section, plus a parametrized run over all registered tests. The
coverage test is the durable part: it fails whenever a CI test is registered
without being documented, which is how the 8-of-14 drift went unnoticed.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)