### PR TITLE
Make pydot graph layouts work and warn on fallback

### DIFF
--- a/causalts/plotting/_core.py
+++ b/causalts/plotting/_core.py
@@ -23,6 +23,7 @@ Public License v3.0. Ensure proper attribution when using or modifying this code
 
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import warnings
 from copy import deepcopy
 from operator import sub
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -1319,8 +1320,17 @@ def compute_node_positions(
                             graphviz_layout as pydot_layout,
                         )
 
-                        pos = pydot_layout(H, prog=prog_to_use, args=args)
+                        # networkx's pydot adapter does not accept the args
+                        # parameter supported by its pygraphviz counterpart.
+                        pos = pydot_layout(H, prog=prog_to_use)
                     except Exception:
+                        warnings.warn(
+                            "Graphviz layout unavailable; falling back to "
+                            "circular layout. Install pygraphviz or pydot "
+                            "with Graphviz installed and on PATH.",
+                            UserWarning,
+                            stacklevel=2,
+                        )
                         pos = nx.circular_layout(H)
             else:
                 pos = nx.circular_layout(H)

--- a/docs/api/plotting.md
+++ b/docs/api/plotting.md
@@ -25,6 +25,13 @@ from causalts.plotting import (
 
 Network layout — nodes are variables, edges are contemporaneous or lagged causal links.
 
+Graphviz-family layouts (`graphviz`, `neato`, `dot`, `fdp`, `sfdp`, `twopi`, and
+`circo`) use the optional `pygraphviz` backend first and then the optional
+`pydot` backend. Both backends require a Graphviz executable (such as `neato`)
+to be installed and available on `PATH`; neither Python package is installed by
+`causalts`. If both backends are unavailable or fail, `causalts` falls back to
+a circular layout and emits a `UserWarning`.
+
 ```{eval-rst}
 .. autofunction:: causalts.plotting._core.plot_graph
 ```

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -4,10 +4,66 @@
 """Smoke tests for plotting (non-interactive Agg backend)."""
 
 import matplotlib
+import pytest
 
 matplotlib.use("Agg")
 
 import numpy as np  # noqa: E402
+
+
+def test_graphviz_layout_uses_pydot_without_unsupported_args(monkeypatch):
+    # Regression test for https://github.com/bloomberg/causal-ts/issues/53.
+    import networkx as nx
+    import networkx.drawing.nx_agraph as nx_agraph
+    import networkx.drawing.nx_pydot as nx_pydot
+
+    from causalts.plotting._core import compute_node_positions
+
+    graph = nx.path_graph(3)
+    expected = {node: np.array([float(node), float(node) + 1]) for node in graph}
+    calls = []
+
+    def unavailable(*args, **kwargs):
+        raise ImportError("pygraphviz is not installed")
+
+    def pydot_layout(graph, prog="neato", root=None):
+        calls.append((prog, root))
+        return expected
+
+    monkeypatch.setattr(nx_agraph, "graphviz_layout", unavailable)
+    monkeypatch.setattr(nx_pydot, "graphviz_layout", pydot_layout)
+
+    positions = compute_node_positions(
+        graph,
+        layout="neato",
+        layout_kwargs={"args": "-Goverlap=false"},
+        normalize=False,
+    )
+
+    assert calls == [("neato", None)]
+    assert all(np.array_equal(positions[node], expected[node]) for node in graph)
+
+
+def test_graphviz_layout_warns_before_circular_fallback(monkeypatch):
+    # Regression test for https://github.com/bloomberg/causal-ts/issues/53.
+    import networkx as nx
+    import networkx.drawing.nx_agraph as nx_agraph
+    import networkx.drawing.nx_pydot as nx_pydot
+
+    from causalts.plotting._core import compute_node_positions
+
+    graph = nx.path_graph(3)
+
+    def unavailable(*args, **kwargs):
+        raise ImportError("Graphviz backend is unavailable")
+
+    monkeypatch.setattr(nx_agraph, "graphviz_layout", unavailable)
+    monkeypatch.setattr(nx_pydot, "graphviz_layout", unavailable)
+
+    with pytest.warns(UserWarning, match="falling back to circular layout"):
+        positions = compute_node_positions(graph, layout="neato", normalize=False)
+
+    assert set(positions) == set(graph)
 
 
 def _make_graph():


### PR DESCRIPTION
## Summary / Problem

Graphviz-family layouts can silently fall back to a circular layout when `pygraphviz` is unavailable. When `pydot` is available, the fallback currently passes an unsupported argument to NetworkX's pydot adapter, so it also fails instead of producing a Graphviz layout.

## Changes

- Call NetworkX's pydot layout adapter with the arguments it supports after the pygraphviz backend fails.
- Emit a `UserWarning` when both optional Graphviz layout backends fail before falling back to a circular layout.
- Document the optional pygraphviz/pydot and Graphviz executable requirements in the plotting API guide.
- Add regression coverage for the pydot path and warning fallback without requiring Graphviz.

## Tests

- `python -m pytest tests/test_plotting.py -q` — 17 passed.
- `python -m pytest tests/ -v --tb=short --basetemp=...` — 436 passed, 1 pre-existing Windows-only failure in `test_turning_phase_terminates_on_known_cycle` because Windows does not provide `signal.SIGALRM`; all plotting tests passed.
- `python -m black --check causalts/plotting/_core.py tests/test_plotting.py` — passed.
- `python -m isort --check-only causalts/plotting/_core.py tests/test_plotting.py` — passed.
- `python -m flake8 --max-line-length=88 --extend-ignore=E501 causalts/plotting/_core.py tests/test_plotting.py` — passed.
- `git diff --check` — passed.

## Compatibility / Known limitations

The existing circular fallback is preserved, but it now emits `UserWarning`. Graphviz executables are not installed on the local Windows host, so the successful pydot adapter call is tested with a mocked adapter; the fallback behavior is tested without Graphviz.

## Issue

Fixes #53
