### PR TITLE
Fix dead notebook-to-notebook links in the rendered docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,13 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+# Notebooks copied into the Sphinx source tree at build time by
+# docs/conf.py:_sync_notebooks. `examples/` and `tutorial.ipynb` at the repo
+# root are canonical; these are generated. They used to be committed symlinks,
+# but myst resolves a symlinked link target to its real path -- outside the
+# Sphinx source root -- so every notebook-to-notebook link rendered dead.
+docs/examples/*.ipynb
+docs/tutorial.ipynb
 
 # PyBuilder
 .pybuilder/
@@ -186,3 +193,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.venv-docsfix/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,5 +176,50 @@ def _localize_announcement(app, pagename, templatename, context, doctree):
     )
 
 
+#: Notebooks live in the repo-root ``examples/`` directory so that relative
+#: links between them work when browsing on GitHub or opening them in Jupyter.
+#: Sphinx has a single source root (``docs/``), so anything outside it has no
+#: docname -- and a symlink is no help, because myst resolves a link target to
+#: its real path before calling ``path2doc``. Linking to a symlinked sibling
+#: therefore produced a dead link and an ``Unknown source document`` warning.
+#:
+#: Copying the notebooks into the source tree at build time puts real files at
+#: ``docs/examples/``, which gives them docnames and makes the plain relative
+#: links resolve. The copies are gitignored; ``examples/`` stays canonical.
+_NOTEBOOK_COPIES = [
+    ("examples", "examples"),  # examples/*.ipynb -> docs/examples/*.ipynb
+]
+
+
+def _sync_notebooks(app):
+    import shutil
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parent.parent
+    for src_rel, dst_rel in _NOTEBOOK_COPIES:
+        src_dir = repo_root / src_rel
+        dst_dir = Path(app.srcdir) / dst_rel
+        if not src_dir.is_dir():
+            continue
+        dst_dir.mkdir(parents=True, exist_ok=True)
+        for src in sorted(src_dir.glob("*.ipynb")):
+            dst = dst_dir / src.name
+            # Replace a stale symlink (or an out-of-date copy) with the real file.
+            if dst.is_symlink():
+                dst.unlink()
+            if not dst.exists() or src.stat().st_mtime > dst.stat().st_mtime:
+                shutil.copy2(src, dst)
+
+    # tutorial.ipynb sits at the repo root and is referenced as ../tutorial
+    tut_src = repo_root / "tutorial.ipynb"
+    tut_dst = Path(app.srcdir) / "tutorial.ipynb"
+    if tut_src.is_file():
+        if tut_dst.is_symlink():
+            tut_dst.unlink()
+        if not tut_dst.exists() or tut_src.stat().st_mtime > tut_dst.stat().st_mtime:
+            shutil.copy2(tut_src, tut_dst)
+
+
 def setup(app):
+    _sync_notebooks(app)
     app.connect("html-page-context", _localize_announcement)

--- a/docs/examples/agentic_discovery.ipynb
+++ b/docs/examples/agentic_discovery.ipynb
@@ -1,1 +1,0 @@
-../../examples/agentic_discovery.ipynb

--- a/docs/examples/api_reference.ipynb
+++ b/docs/examples/api_reference.ipynb
@@ -1,1 +1,0 @@
-../../examples/api_reference.ipynb

--- a/docs/examples/background_knowledge.ipynb
+++ b/docs/examples/background_knowledge.ipynb
@@ -1,1 +1,0 @@
-../../examples/background_knowledge.ipynb

--- a/docs/examples/baseline_comparison.ipynb
+++ b/docs/examples/baseline_comparison.ipynb
@@ -1,1 +1,0 @@
-../../examples/baseline_comparison.ipynb

--- a/docs/examples/beginners_guide.ipynb
+++ b/docs/examples/beginners_guide.ipynb
@@ -1,1 +1,0 @@
-../../examples/beginners_guide.ipynb

--- a/docs/examples/cdnots_or_cdnots_plus.ipynb
+++ b/docs/examples/cdnots_or_cdnots_plus.ipynb
@@ -1,1 +1,0 @@
-../../examples/cdnots_or_cdnots_plus.ipynb

--- a/docs/examples/cedar_benchmark.ipynb
+++ b/docs/examples/cedar_benchmark.ipynb
@@ -1,1 +1,0 @@
-../../examples/cedar_benchmark.ipynb

--- a/docs/examples/cedar_deep_dive.ipynb
+++ b/docs/examples/cedar_deep_dive.ipynb
@@ -1,1 +1,0 @@
-../../examples/cedar_deep_dive.ipynb

--- a/docs/examples/cedar_lag_selection.ipynb
+++ b/docs/examples/cedar_lag_selection.ipynb
@@ -1,1 +1,0 @@
-../../examples/cedar_lag_selection.ipynb

--- a/docs/examples/ci_test_comparison.ipynb
+++ b/docs/examples/ci_test_comparison.ipynb
@@ -1,1 +1,0 @@
-../../examples/ci_test_comparison.ipynb

--- a/docs/examples/custom_algorithm.ipynb
+++ b/docs/examples/custom_algorithm.ipynb
@@ -1,1 +1,0 @@
-../../examples/custom_algorithm.ipynb

--- a/docs/examples/custom_ci_test.ipynb
+++ b/docs/examples/custom_ci_test.ipynb
@@ -1,1 +1,0 @@
-../../examples/custom_ci_test.ipynb

--- a/docs/examples/effect_estimation.ipynb
+++ b/docs/examples/effect_estimation.ipynb
@@ -1,1 +1,0 @@
-../../examples/effect_estimation.ipynb

--- a/docs/examples/elbe_river.ipynb
+++ b/docs/examples/elbe_river.ipynb
@@ -1,1 +1,0 @@
-../../examples/elbe_river.ipynb

--- a/docs/examples/feature_selection.ipynb
+++ b/docs/examples/feature_selection.ipynb
@@ -1,1 +1,0 @@
-../../examples/feature_selection.ipynb

--- a/docs/examples/forecasting.ipynb
+++ b/docs/examples/forecasting.ipynb
@@ -1,1 +1,0 @@
-../../examples/forecasting.ipynb

--- a/docs/examples/grace_ablation.ipynb
+++ b/docs/examples/grace_ablation.ipynb
@@ -1,1 +1,0 @@
-../../examples/grace_ablation.ipynb

--- a/docs/examples/grace_high_dim.ipynb
+++ b/docs/examples/grace_high_dim.ipynb
@@ -1,1 +1,0 @@
-../../examples/grace_high_dim.ipynb

--- a/docs/examples/latent_confounder_detection.ipynb
+++ b/docs/examples/latent_confounder_detection.ipynb
@@ -1,1 +1,0 @@
-../../examples/latent_confounder_detection.ipynb

--- a/docs/examples/missing_values.ipynb
+++ b/docs/examples/missing_values.ipynb
@@ -1,1 +1,0 @@
-../../examples/missing_values.ipynb

--- a/docs/examples/mixed_data.ipynb
+++ b/docs/examples/mixed_data.ipynb
@@ -1,1 +1,0 @@
-../../examples/mixed_data.ipynb

--- a/docs/examples/multi_c_nonstationarity.ipynb
+++ b/docs/examples/multi_c_nonstationarity.ipynb
@@ -1,1 +1,0 @@
-../../examples/multi_c_nonstationarity.ipynb

--- a/docs/examples/plotting.ipynb
+++ b/docs/examples/plotting.ipynb
@@ -1,1 +1,0 @@
-../../examples/plotting.ipynb

--- a/docs/examples/probabilistic_queries.ipynb
+++ b/docs/examples/probabilistic_queries.ipynb
@@ -1,1 +1,0 @@
-../../examples/probabilistic_queries.ipynb

--- a/docs/examples/regime_discovery.ipynb
+++ b/docs/examples/regime_discovery.ipynb
@@ -1,1 +1,0 @@
-../../examples/regime_discovery.ipynb

--- a/docs/examples/subsampling.ipynb
+++ b/docs/examples/subsampling.ipynb
@@ -1,1 +1,0 @@
-../../examples/subsampling.ipynb

--- a/docs/examples/tigramite_integration.ipynb
+++ b/docs/examples/tigramite_integration.ipynb
@@ -1,1 +1,0 @@
-../../examples/tigramite_integration.ipynb

--- a/docs/examples/weather_benchmark.ipynb
+++ b/docs/examples/weather_benchmark.ipynb
@@ -1,1 +1,0 @@
-../../examples/weather_benchmark.ipynb

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -1,1 +1,0 @@
-../tutorial.ipynb


### PR DESCRIPTION
## Summary
- Notebook-to-notebook markdown links (e.g. `beginners_guide.ipynb` linking to `effect_estimation.ipynb`) render as dead, non-clickable references in the built docs, because `docs/examples/*.ipynb` are symlinks to the canonical copies in `examples/`. myst resolves a link target to its real path before looking up a docname, and only `docs/` is in the Sphinx source tree — so the resolved path has no docname and the link fails.
- `docs/conf.py:_sync_notebooks` now copies `examples/*.ipynb` and `tutorial.ipynb` into the source tree at build time. The copies are gitignored; `examples/` stays the canonical, GitHub- and Jupyter-browsable location. No notebook content changes.
- Verified on a clean build of `main`: **17 `Unknown source document` warnings → 0**, affecting `beginners_guide.ipynb` (6 dead links, including the entry-point tutorial's own forward references), `tutorial.ipynb` (4), `latent_confounder_detection.ipynb` (5), and `effect_estimation.ipynb` (1).

## Test plan
- [x] `python -m sphinx -b html docs <outdir>` on `main`: 17 dead sibling-notebook links (`Unknown source document`), build otherwise succeeds
- [x] Same build after this change: 0 dead links, warnings 288 → 271
- [x] Deleted a generated copy (`docs/examples/beginners_guide.ipynb`) and rebuilt — confirmed the hook regenerates it
- [x] `black --check`, `isort --check`, `flake8` clean on `docs/conf.py`
- [x] `codespell` (repo config) clean on `docs/conf.py` and `.gitignore`
- [x] Spot-checked rendered HTML: links resolve to real `<a href>` targets, not text