### PR TITLE
feat: bridge causal-ts GPU CI tests into causal-learn's CIT registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+* `causalts.ci_tests.causal_learn_bridge` — registers causal-ts's GPU CI tests
+  with causal-learn's `CIT()` factory/`register_ci_test()`, so they can be
+  used directly from causal-learn's own algorithms (e.g.
+  `pc(data, indep_test="parcorr_gpu")`).
 * **LUCID** (`causalts.confounders`) — regime-adaptive deconfounding for causal discovery
   under latent confounders. `run_lucid(df, max_lag)` diagnoses whether latent confounding
   is sparse or pervasive from the residual spectrum (against a Marchenko–Pastur no-factor

--- a/causalts/ci_tests/causal_learn_bridge.py
+++ b/causalts/ci_tests/causal_learn_bridge.py
@@ -1,0 +1,81 @@
+# Copyright 2025 Bloomberg Finance L.P.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Exposes causal-ts's GPU CI tests through causal-learn's CIT registry.
+
+Importing this module registers every causal-ts GPU CI test with
+``causallearn.utils.cit.register_ci_test``, so they become selectable by
+name from causal-learn's own factory and algorithms::
+
+    import causalts.ci_tests.causal_learn_bridge  # registers on import
+    from causallearn.utils.cit import CIT
+    from causallearn.search.ConstraintBased.PC import pc
+
+    cit = CIT(data, method="parcorr_gpu")
+    g = pc(data, indep_test=cit)
+
+causal-learn's ``CIT_Base.__call__`` contract returns a single p-value,
+while causal-ts CI tests return ``(p_value, statistic)``; the adapter below
+unwraps that tuple.
+
+``CMIknnMixedGPU`` and ``StratifiedCIT`` are deliberately excluded: both
+have required constructor arguments (``discrete_cols``, and for
+``StratifiedCIT`` also a pre-built ``inner_cit``) with no defaults, so they
+cannot be selected by bare name the way the tests below are — a caller would
+still need to pass those through ``CIT(..., **kwargs)`` by hand, at which
+point there is no benefit over instantiating them directly. ``StratifiedCIT``
+is also documented as an internal wrapper not meant for factory selection.
+"""
+
+from .cmiknn_gpu import CMIknnGPU
+from .dfcit_gpu import DFCITGPU
+from .gcmi_gpu import GCMIGPU
+from .kci_gpu import KCIGPU
+from .parcorr_gpu import ParCorrGPU
+from .pyRcot_gpu import RCOTGPU
+from .sigkci_gpu import SigKCIGPU
+from .splitkci_gpu import SplitKCIGPU
+
+_REGISTRY = {
+    "parcorr_gpu": ParCorrGPU,
+    "kci_gpu": KCIGPU,
+    "splitkci_gpu": SplitKCIGPU,
+    "dfcit_gpu": DFCITGPU,
+    "rcot_gpu": RCOTGPU,
+    "cmiknn_gpu": CMIknnGPU,
+    "gcmi_gpu": GCMIGPU,
+    "sigkci_gpu": SigKCIGPU,
+}
+
+
+def _make_adapter(name, causalts_cls):
+    from causallearn.utils.cit import CIT_Base as CLCITBase
+
+    class _Adapter(CLCITBase):
+        def __init__(self, data, cache_path=None, **kwargs):
+            super().__init__(data, cache_path=cache_path)
+            self.method = name
+            self._inner = causalts_cls(data=data, **kwargs)
+
+        def __call__(self, X, Y, condition_set=None):
+            pval, _stat = self._inner(X, Y, condition_set)
+            return float(pval)
+
+    _Adapter.__name__ = f"CausalTS_{causalts_cls.__name__}"
+    _Adapter.__qualname__ = _Adapter.__name__
+    return _Adapter
+
+
+def register_all():
+    """Register every causal-ts GPU CI test with causal-learn's CIT factory.
+
+    Safe to call more than once; later calls just re-register the same
+    classes under the same names.
+    """
+    from causallearn.utils.cit import register_ci_test
+
+    for name, cls in _REGISTRY.items():
+        register_ci_test(name, _make_adapter(name, cls))
+
+
+register_all()

--- a/tests/test_causal_learn_bridge.py
+++ b/tests/test_causal_learn_bridge.py
@@ -1,0 +1,60 @@
+# Copyright 2025 Bloomberg Finance L.P.
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import numpy as np
+import pytest
+from causallearn.utils.cit import CIT
+
+import causalts.ci_tests.causal_learn_bridge as bridge
+
+# Excluded from the registry: both require constructor arguments with no
+# defaults (discrete_cols, and for StratifiedCIT also a pre-built inner_cit),
+# so they can't be selected by bare name the way the registered tests are.
+EXCLUDED_FROM_REGISTRY = {"cmiknn_mixed_gpu", "stratified_cit"}
+
+
+def _make_data(n=300, seed=0):
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal(n)
+    z = rng.standard_normal(n)
+    y = 0.5 * x + 0.3 * z + 0.1 * rng.standard_normal(n)
+    return np.column_stack([x, y, z])
+
+
+@pytest.mark.parametrize("name", sorted(bridge._REGISTRY))
+def test_registered_test_returns_pvalue(name):
+    data = _make_data()
+    cit = CIT(data, method=name, device="cpu")
+    pval = cit(0, 1, [2])
+    assert isinstance(pval, float)
+    assert 0.0 <= pval <= 1.0
+    assert cit.method == name
+
+
+@pytest.mark.parametrize("name", sorted(EXCLUDED_FROM_REGISTRY))
+def test_tests_requiring_extra_kwargs_are_not_registered(name):
+    assert name not in bridge._REGISTRY
+    data = _make_data()
+    with pytest.raises(ValueError):
+        CIT(data, method=name)
+
+
+def test_unknown_method_still_raises():
+    data = _make_data()
+    with pytest.raises(ValueError):
+        CIT(data, method="not_a_real_method")
+
+
+def test_pc_algorithm_runs_with_registered_test():
+    from causallearn.search.ConstraintBased.PC import pc
+
+    rng = np.random.default_rng(0)
+    n = 300
+    x = rng.standard_normal(n)
+    z = rng.standard_normal(n)
+    y = 0.5 * x + 0.3 * z + 0.1 * rng.standard_normal(n)
+    w = 0.4 * y + 0.1 * rng.standard_normal(n)
+    data = np.column_stack([x, y, z, w])
+
+    cg = pc(data, indep_test="parcorr_gpu", device="cpu", show_progress=False)
+    assert cg.G.graph.shape == (4, 4)


### PR DESCRIPTION
## Summary
- Adds `causalts/ci_tests/causal_learn_bridge.py`, wrapping our GPU CI tests to conform to causal-learn's `CIT_Base.__call__` contract and registering them via `register_ci_test()`.
- Registers: `parcorr_gpu`, `kci_gpu`, `splitkci_gpu`, `dfcit_gpu`, `rcot_gpu`, `cmiknn_gpu`, `gcmi_gpu`, `sigkci_gpu`.
- Lets users run causal-learn's own algorithms (e.g. `pc`, `fci`) with our GPU CI tests directly, e.g. `pc(data, indep_test="parcorr_gpu")`.
- `CMIknnMixedGPU` and `StratifiedCIT` are intentionally excluded — both require constructor args with no defaults (`discrete_cols`, and for `StratifiedCIT` a pre-built `inner_cit`), so they can't be selected by bare name.
- This is intended as a stepping stone toward a docs-only PR to py-why/causal-learn documenting their (currently undocumented) `register_ci_test` extension point, linking causal-ts as a real usage example.

## Test plan
- [x] `pytest tests/test_causal_learn_bridge.py` — 12/12 passing, covers all 8 registered tests, the two excluded tests correctly raising `ValueError`, and a live `pc()` run.
- [x] black / isort / flake8 clean
- [x] codespell clean