### PR TITLE
fix: resolve zizmor cache-poisoning finding in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,6 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: pyproject.toml
 
       - name: install dependencies
         run: |
@@ -84,8 +82,6 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-          cache: pip
-          cache-dependency-path: pyproject.toml
 
       - name: verify release tag matches package version
         if: github.event_name == 'release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -77,6 +78,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
## Summary
- zizmor flags `actions/setup-python`'s `cache: pip` in release.yml as a low-confidence cache-poisoning risk, since the workflow is triggered by `release: types: [published]`.
- super-linter only lints changed files, so this pre-existing finding first surfaces on any PR that touches release.yml — e.g. dependabot PRs #24 and #25, which are currently blocked on it.
- Drop the pip cache from the two `setup-python` steps (test + build jobs); both run once per release, so caching buys little.

## Test plan
- [x] `lint` job (super-linter) passes on this PR
- [ ] After merge, rebase #24 and #25 and confirm their `lint` checks go green