### PR TITLE
fix: set persist-credentials: false on remaining workflow checkouts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,6 +60,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/dependency.yml
+++ b/.github/workflows/dependency.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: 🔂 dependency review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0


### PR DESCRIPTION
## Summary
- Follow-up to #60. That PR fixed zizmor's `artipacked` finding in release.yml, but the same pattern exists in codeql.yml, dependency.yml, and test.yml.
- Because zizmor only lints files a PR actually touches, this was hidden until a PR edits those files directly — which is exactly what dependabot's PRs #24/#25 do (they bump pinned action SHAs across every workflow file), so their `super-linter` check now flags it.
- None of the affected jobs hold `contents: write`, so nothing relies on the persisted git credential; this is a no-op functionally.

## Test plan
- [x] `super-linter` passes on this PR
- [ ] After merge, rebase #24 and #25 again and confirm `super-linter` is green