### PR TITLE
release: bump version to 0.27.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "causal-ts-discovery",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Agent skill for causal discovery in nonstationary time series with causal-ts — inspects data health, auto-selects an algorithm (CDNOTS/Cedar/GRACE) and CI test, runs discovery, and interprets the causal graph.",
   "author": {
     "name": "Causal-TS authors"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.27.0]
+
 ### Added
 
-* `causalts.ci_tests.causal_learn_bridge` — registers causal-ts's GPU CI tests
-  with causal-learn's `CIT()` factory/`register_ci_test()`, so they can be
-  used directly from causal-learn's own algorithms (e.g.
-  `pc(data, indep_test="parcorr_gpu")`).
-* **DoWhy effects bridge.** `validate_transition_graph()` and `history_sufficiency()`
-  validate a lag-embedded graph (replacing the deprecated `falsify_graph()`);
-  `refute_effect()` and `sensitivity_analysis()` stress-test an estimate;
-  `build_identification_artifacts()` / `build_transition_artifacts()` hand back a graph
-  and the frame it belongs with, for driving DoWhy directly. All are on the result
-  objects, and `causal-ts dowhy validate --test` exposes the validators from the CLI.
 * **LUCID** (`causalts.confounders`) — regime-adaptive deconfounding for causal discovery
   under latent confounders. `run_lucid(df, max_lag)` diagnoses whether latent confounding
   is sparse or pervasive from the residual spectrum (against a Marchenko–Pastur no-factor
@@ -30,6 +22,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   with any algorithm, without re-running the skeleton search. See the new
   [Unobserved Confounders (LUCID)](examples/latent_confounder_detection) tutorial and the
   `causalts.confounders` API page.
+* **DoWhy effects bridge.** `validate_transition_graph()` and `history_sufficiency()`
+  validate a lag-embedded graph (replacing the deprecated `falsify_graph()`);
+  `refute_effect()` and `sensitivity_analysis()` stress-test an estimate;
+  `build_identification_artifacts()` / `build_transition_artifacts()` hand back a graph
+  and the frame it belongs with, for driving DoWhy directly. All are on the result
+  objects, and `causal-ts dowhy validate --test` exposes the validators from the CLI.
 * `corrplot(..., diag="glyph")` — renders the diagonal as an ordinary cell,
   using the same `method` and colormap as the rest of the matrix. Intended for
   *directed* matrices (a cause→effect adjacency or an edge-stability matrix),
@@ -43,6 +41,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   causal effect — a lagged treatment had no parents, so no backdoor path was found. The
   graph is now unrolled and the adjustment set verified against the fitted estimator.
   ATEs change.
+* **The GES, LGES and TGES baselines were substantially understated.** `ges_discovery`
+  read causal-learn's adjacency matrix with the endpoints transposed, and the vendored
+  GES search behind `lges_discovery` / `tges_discovery` had a broken CPDAG construction
+  that stopped LGES far short of convergence. Both are fixed and now apply temporal
+  background knowledge; F1 on `baseline_comparison` moves from 0.125–0.522 to 0.636–0.949.
+  Any prior comparison against these baselines understates them.
 * `refute_effect()` no longer reports an uncomputable refutation as a failure, and
   `refute_structure()` returns `p_value` and `adjusted_p_value` separately. DoWhy's
   renamed identification APIs are bound by capability, not version.
@@ -63,29 +67,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 * The generator in the *Unobserved Confounders (LUCID)* tutorial injected its true lag-1
   edges after the recursion instead of inside it, so the simulated data did not match the
   ground truth the notebook scored against.
-
-* **The GES, LGES and TGES baselines were substantially understated.** Two independent
-  problems, both now fixed and covered by regression tests:
-  * `ges_discovery` read causal-learn's adjacency matrix with the endpoints transposed,
-    so every directed contemporaneous edge came back reversed and every directed lagged
-    edge was silently dropped — only undirected edges survived.
-  * The vendored GES search behind `lges_discovery` / `tges_discovery`
-    (`causalts/lges.py`) is a hand-extracted condensation of upstream `ges`, and the
-    extraction broke the CPDAG construction and the Insert, Delete and Turn operators.
-    The forward phase stopped far short of the optimum, so LGES never converged — its
-    F1 sat at 0.35–0.52 on `ex2` no matter how much data it was given.
-
-  All three now also apply temporal background knowledge (a variable can only cause
-  another at an equal or later time step), which the lag-embedded search previously
-  ignored. On the `baseline_comparison` datasets, F1 moves from 0.125/0.154/0.522/0.333
-  (GES) and 0.400/0.417/0.526/0.333 (LGES/TGES) to 0.636/0.917/0.949/0.435 for all
-  three; LGES now reaches F1 1.000 on `ex2` by T=5,000. Every correction was verified
-  against upstream `ges` 1.1.1 — no defect originated with the upstream authors — and
-  the corrected search returns CPDAGs identical to upstream's on random DAGs while
-  running faster than it. `ges_discovery` gains an `engine=` argument selecting the
-  vendored search (default) or causal-learn.
-
-  Any prior comparison against these baselines understates them.
 * `corrplot` dropped the right and bottom edges of its grid border. All axes
   spines are hidden, and the border was drawn with `axhline`/`axvline` at
   exactly the axis limits, so half of each boundary line fell outside the clip
@@ -182,7 +163,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 * Synthetic data generators (nonstationary, mixed discrete-continuous, Lorenz-96)
 
 
-[unreleased]: https://github.com/bloomberg/causal-ts/compare/v0.26.0...HEAD
+[unreleased]: https://github.com/bloomberg/causal-ts/compare/v0.27.0...HEAD
+[0.27.0]: https://github.com/bloomberg/causal-ts/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/bloomberg/causal-ts/compare/v0.25.2...v0.26.0
 [0.25.2]: https://github.com/bloomberg/causal-ts/compare/v0.25.1...v0.25.2
 

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "v0.26 (stable)",
+    "name": "v0.27 (stable)",
     "version": "stable",
     "url": "https://causal-ts.readthedocs.io/en/stable/",
     "preferred": true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,14 +85,13 @@ html_show_sourcelink = False
 # it pointed at examples/examples/... and 404'd. The link target is filled in
 # per page from ``pathto`` in ``_localize_announcement`` below; this literal is
 # the root-relative fallback for the (unused) case where no context is present.
-ANNOUNCEMENT_TARGET = "examples/agentic_discovery"
+ANNOUNCEMENT_TARGET = "examples/latent_confounder_detection"
 ANNOUNCEMENT_LEAD = (
-    "🚀 New in v0.26 — the <code>causal-ts-discovery</code> agent skill, "
-    "a <code>causal-ts inspect</code> pre-flight, and causal feature selection."
+    "🚀 New in v0.27 — <code>LUCID</code>, regime-adaptive deconfounding for "
+    "causal discovery under latent confounders, plus a DoWhy effects bridge "
+    "for transition validation and refutation."
 )
-ANNOUNCEMENT_HTML = (
-    ANNOUNCEMENT_LEAD + " <a href='{link}'>See the agentic workflow →</a>"
-)
+ANNOUNCEMENT_HTML = ANNOUNCEMENT_LEAD + " <a href='{link}'>See LUCID →</a>"
 
 html_theme_options = {
     "announcement": ANNOUNCEMENT_HTML.format(link=f"{ANNOUNCEMENT_TARGET}.html"),

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -160,7 +160,7 @@ Notebooks reproducing experiments from the GRACE paper (preprint forthcoming) wi
 
 <div class="ct-gallery">
 
-<a href="effect_estimation.html" class="ct-gallery-item" data-tooltip="End-to-end DoWhy integration: estimate causal effects, fit SCMs, run counterfactuals, root cause analysis, and graph falsification.">
+<a href="effect_estimation.html" class="ct-gallery-item" data-tooltip="End-to-end DoWhy integration: estimate causal effects, fit SCMs, run counterfactuals, root cause analysis, transition-structure validation, and refutation.">
   <img src="../_static/img/thumbnails/effect_estimation_thumb.png" alt="Effect Estimation" />
   <span class="ct-gallery-title">Effect Estimation</span>
 </a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -139,8 +139,16 @@ Estimate causal effects, fit SCMs, run counterfactuals, and attribute anomalies 
 
 ::::
 
-::::{grid} 2
+::::{grid} 3
 :gutter: 3
+
+:::{grid-item-card} {fas}`eye-slash;1.1em;sd-text-primary` &nbsp; Latent Confounders (LUCID)
+:link: api/confounders
+:link-type: doc
+:shadow: sm
+
+Diagnose whether latent confounding is sparse or pervasive from the residual spectrum, then apply the matching correction to any discovered graph.
+:::
 
 :::{grid-item-card} {fas}`table-cells-large;1.1em;sd-text-primary` &nbsp; Missing & Mixed Data
 :link: examples/index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "causalts"
-version = "0.26.0"
+version = "0.27.0"
 description = "Causal Discovery for Time Series"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` and the `causal-ts-discovery` skill's `.claude-plugin/plugin.json` to 0.27.0.
- Moves the changelog's `[Unreleased]` section into `[0.27.0]`, reordered to lead with LUCID, then the DoWhy effects bridge, then the GES/LGES/TGES baseline fix (shortened to match the length of neighboring entries); `run_cdnots_plus` default changes already led the Changed section.
- Refreshes `docs/_static/switcher.json` and the `docs/conf.py` announcement banner for the new release, pointing at the LUCID tutorial.
- Fixes two other docs pages that had drifted: the `effect_estimation` gallery tooltip in `docs/examples/index.md` still referenced the deprecated `falsify_graph()` instead of the new validation/refutation bridge, and the landing page (`docs/index.md`) Features grid had no card for LUCID/deconfounding despite it being the headline feature this release.

## Test plan
- [x] black / isort / flake8 / codespell all pass on the changed files
- [x] `docs/index.md` grid-fence balance verified (9 card opens/closes, 3 container opens/closes)
- [ ] After merge, dry-run `release.yml` via `workflow_dispatch` to build+smoke-test the wheel before cutting the actual `v0.27.0` tag/release