### PR TITLE
fix: point Edit on GitHub at the real notebook, not its build-time copy

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,6 +175,23 @@ def _localize_announcement(app, pagename, templatename, context, doctree):
     )
 
 
+def _fix_edit_page_source(app, pagename, templatename, context, doctree):
+    """Point "Edit on GitHub" at the real notebook, not its build-time copy.
+
+    ``examples/*.ipynb`` and ``tutorial.ipynb`` are synced into the source
+    tree from the repo root (see ``_sync_notebooks`` below) and are
+    gitignored there. The theme's default edit-page template joins
+    ``doc_path`` (``"docs/"``) with the page name, which for these pages
+    produces a nonexistent ``docs/examples/*.ipynb`` / ``docs/tutorial.ipynb``
+    URL that 404s. Their real home is the repo root, so clear ``doc_path``
+    for them; every other page keeps the default.
+    """
+    if context.get("page_source_suffix") != ".ipynb":
+        return
+    if pagename == "tutorial" or pagename.startswith("examples/"):
+        context["doc_path"] = ""
+
+
 #: Notebooks live in the repo-root ``examples/`` directory so that relative
 #: links between them work when browsing on GitHub or opening them in Jupyter.
 #: Sphinx has a single source root (``docs/``), so anything outside it has no
@@ -222,3 +239,4 @@ def _sync_notebooks(app):
 def setup(app):
     _sync_notebooks(app)
     app.connect("html-page-context", _localize_announcement)
+    app.connect("html-page-context", _fix_edit_page_source)


### PR DESCRIPTION
## Summary
- The "Edit on GitHub" button 404s on every notebook page (`examples/*.html` and `tutorial.html`).
- `examples/*.ipynb` and `tutorial.ipynb` are synced into the Sphinx source tree from the repo root at build time (see `_sync_notebooks` in `docs/conf.py`) and are gitignored in `docs/`. The theme's default edit-page template joins `doc_path` (`"docs/"`) with the page name, so it links to a `docs/examples/*.ipynb` / `docs/tutorial.ipynb` path that doesn't exist in the repo.
- Clears `doc_path` for these specific pages so the link resolves to their real repo-root location. Every other page (anything genuinely sourced under `docs/`) is unaffected.

## Test plan
- [x] Local `sphinx-build -b html docs docs/_build/html_test` and inspected the rendered "Edit on GitHub" href:
  - `examples/effect_estimation.html` → `.../edit/main/examples/effect_estimation.ipynb` (exists)
  - `tutorial.html` → `.../edit/main/tutorial.ipynb` (exists)
  - Spot-checked `latent_confounder_detection`, `agentic_discovery`, `cedar_deep_dive` — all correct
  - `docs/index.md`, `docs/examples/index.md`, `docs/api/effects.md` (genuine docs/ sources) unaffected, still `.../edit/main/docs/...`
- [x] black / isort / flake8 / codespell pass