### PR TITLE
fix: grant scorecard's reusable workflow the permissions it needs

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   run-scorecard:
     # Call reusable workflow file
-    uses: bloomberg/.github/.github/workflows/_scorecard.yml@main
+    uses: bloomberg/.github/.github/workflows/_scorecard.yml@6e6478c5f719f8ac2251558635f700dd5c0f128e # main
     permissions:
       id-token: write
       security-events: write
@@ -28,7 +28,6 @@ jobs:
       issues: read
       pull-requests: read
       checks: read
-    secrets: inherit
     with:
       # Publish results of Scorecard analysis
       publish-results: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,6 +24,10 @@ jobs:
     permissions:
       id-token: write
       security-events: write
+      contents: read
+      issues: read
+      pull-requests: read
+      checks: read
     secrets: inherit
     with:
       # Publish results of Scorecard analysis

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,7 @@ jobs:
     # _stale.yml needs secrets.BLOOMBERG_OSS_USER_TOKEN_READ for actions/stale's
     # repo-token, but its workflow_call trigger declares no `secrets:` schema, so
     # there is no way to pass it explicitly -- inherit is the only option here.
-    secrets: inherit  # zizmor: ignore[secrets-inherit]
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     with:
       days-until-stale: 60
       days-until-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,11 +14,15 @@ permissions: read-all
 jobs:
   mark-stale:
     # Call reusable workflow file
-    uses: bloomberg/.github/.github/workflows/_stale.yml@main
+    uses: bloomberg/.github/.github/workflows/_stale.yml@6e6478c5f719f8ac2251558635f700dd5c0f128e # main
     permissions:
       contents: read
       issues: write
       pull-requests: write
+    # _stale.yml needs secrets.BLOOMBERG_OSS_USER_TOKEN_READ for actions/stale's
+    # repo-token, but its workflow_call trigger declares no `secrets:` schema, so
+    # there is no way to pass it explicitly -- inherit is the only option here.
+    secrets: inherit  # zizmor: ignore[secrets-inherit]
     with:
       days-until-stale: 60
       days-until-close: 7


### PR DESCRIPTION
## Summary
- `scorecard.yml` has been failing on every push to `main` and every scheduled run with `startup_failure` and **zero jobs created**, going back to at least 2026-08-19 — a pre-existing issue, not caused by any of our recent changes.
- Root cause: the caller job only granted the reusable workflow (`bloomberg/.github/.github/workflows/_scorecard.yml`) `id-token: write` and `security-events: write`, but that workflow's job also requests `contents: read`, `issues: read`, `pull-requests: read`, and `checks: read`. A reusable workflow can't be granted more permissions than its caller allows, so GitHub rejects the call before dispatching any job.
- While investigating with `zizmor` (the security linter super-linter runs), found and fixed two more issues, both pre-existing and only surfaced because this is the first PR to touch these files:
  - Both `scorecard.yml` and `stale.yml` pin their `bloomberg/.github` reusable workflow calls to the mutable `@main` ref instead of a commit SHA (`unpinned-uses`, High confidence).
  - `stale.yml` never passed `secrets: inherit`, but `_stale.yml`'s `repo-token` needs `secrets.BLOOMBERG_OSS_USER_TOKEN_READ` — **every scheduled `stale` run has been failing** with `Parameter token or opts.auth is required` since at least 2026-08-08 (confirmed via `gh run view` logs). Added `secrets: inherit` with an inline `zizmor: ignore[secrets-inherit]` since `_stale.yml`'s `workflow_call` trigger declares no `secrets:` schema, so there's no way to pass it explicitly.
  - `scorecard.yml`'s `secrets: inherit` was dropped as unnecessary: none of `_scorecard.yml`'s steps reference a secret by name, and `repo_token` for `ossf/scorecard-action` defaults to `${{ github.token }}` (confirmed by reading the action's `action.yaml`).

## Test plan
- [x] Manually dispatched `scorecard.yml` on this branch before and after the permissions fix:
  - **Before**: `startup_failure`, 0 jobs, ~1s (https://github.com/bloomberg/causal-ts/actions/runs/34517942401)
  - **After**: a real job started and ran (https://github.com/bloomberg/causal-ts/actions/runs/34518161953) — it failed with `Only the default branch main is supported`, which is `ossf/scorecard-action`'s own guard against non-default-branch runs, unrelated to permissions. Confirms the fix; full verification needs a run against `main`.
- [x] `zizmor .github/workflows/` locally: clean across every workflow file (`No findings to report`)
- [x] codespell / YAML parse both pass
- [ ] After merge, confirm the next scheduled/dispatched `scorecard` and `stale` runs complete successfully on `main`